### PR TITLE
Make tests and linter pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Get
         run: flutter pub get
       - name: Analyze
-        run: flutter analyze || echo "Ignore Analyze temporarily."
+        run: flutter analyze
       - name: Test
-        run: flutter test || echo "Ignore Analyze temporarily."
+        run: flutter test
       - name: Build
         run: flutter build aot

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,90 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def parse_KV_file(file, separator='=')
+  file_abs_path = File.expand_path(file)
+  if !File.exists? file_abs_path
+    return [];
+  end
+  generated_key_values = {}
+  skip_line_start_symbols = ["#", "/"]
+  File.foreach(file_abs_path) do |line|
+    next if skip_line_start_symbols.any? { |symbol| line =~ /^\s*#{symbol}/ }
+    plugin = line.split(pattern=separator)
+    if plugin.length == 2
+      podname = plugin[0].strip()
+      path = plugin[1].strip()
+      podpath = File.expand_path("#{path}", file_abs_path)
+      generated_key_values[podname] = podpath
+    else
+      puts "Invalid plugin specification: #{line}"
+    end
+  end
+  generated_key_values
+end
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+  
+  # Flutter Pod
+
+  copied_flutter_dir = File.join(__dir__, 'Flutter')
+  copied_framework_path = File.join(copied_flutter_dir, 'Flutter.framework')
+  copied_podspec_path = File.join(copied_flutter_dir, 'Flutter.podspec')
+  unless File.exist?(copied_framework_path) && File.exist?(copied_podspec_path)
+    # Copy Flutter.framework and Flutter.podspec to Flutter/ to have something to link against if the xcode backend script has not run yet.
+    # That script will copy the correct debug/profile/release version of the framework based on the currently selected Xcode configuration.
+    # CocoaPods will not embed the framework on pod install (before any build phases can generate) if the dylib does not exist.
+
+    generated_xcode_build_settings_path = File.join(copied_flutter_dir, 'Generated.xcconfig')
+    unless File.exist?(generated_xcode_build_settings_path)
+      raise "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+    end
+    generated_xcode_build_settings = parse_KV_file(generated_xcode_build_settings_path)
+    cached_framework_dir = generated_xcode_build_settings['FLUTTER_FRAMEWORK_DIR'];
+
+    unless File.exist?(copied_framework_path)
+      FileUtils.cp_r(File.join(cached_framework_dir, 'Flutter.framework'), copied_flutter_dir)
+    end
+    unless File.exist?(copied_podspec_path)
+      FileUtils.cp(File.join(cached_framework_dir, 'Flutter.podspec'), copied_flutter_dir)
+    end
+  end
+
+  # Keep pod path relative so it can be checked into Podfile.lock.
+  pod 'Flutter', :path => 'Flutter'
+
+  # Plugin Pods
+
+  # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
+  # referring to absolute paths on developers' machines.
+  system('rm -rf .symlinks')
+  system('mkdir -p .symlinks/plugins')
+  plugin_pods = parse_KV_file('../.flutter-plugins')
+  plugin_pods.each do |name, path|
+    symlink = File.join('.symlinks', 'plugins', name)
+    File.symlink(path, symlink)
+    pod name, :path => File.join(symlink, 'ios')
+  end
+end
+
+# Prevent Cocoapods from embedding a second Flutter framework and causing an error with the new Xcode build system.
+install! 'cocoapods', :disable_input_output_paths => true
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['ENABLE_BITCODE'] = 'NO'
+    end
+  end
+end

--- a/lib/Home.dart
+++ b/lib/Home.dart
@@ -3,7 +3,7 @@ import 'Upcoming.dart';
 import 'Login.dart';
 
 class Greeting extends StatelessWidget {
-  String name;
+  final String name;
 
   Greeting({@required this.name});
 
@@ -20,7 +20,7 @@ class Greeting extends StatelessWidget {
 }
 
 class LeftSubheading extends StatelessWidget {
-  String heading;
+  final String heading;
 
   LeftSubheading({@required this.heading});
 

--- a/lib/Login.dart
+++ b/lib/Login.dart
@@ -50,11 +50,6 @@ class _LoginState extends State<Login> {
     super.initState();
     currentUser = null;
     success = false;
-    try {
-      googleSignIn.signInSilently(); }
-    catch (error) {
-      googleSignIn.signIn();
-    }
     googleSignIn.onCurrentUserChanged.listen((GoogleSignInAccount account) {
       setCurrentUser(account);
       tokenFromAccount(currentUser).then((token) async {

--- a/lib/Login.dart
+++ b/lib/Login.dart
@@ -50,6 +50,11 @@ class _LoginState extends State<Login> {
     super.initState();
     currentUser = null;
     success = false;
+    try {
+      googleSignIn.signInSilently();
+    } catch (error) {
+      googleSignIn.signIn();
+    }
     googleSignIn.onCurrentUserChanged.listen((GoogleSignInAccount account) {
       setCurrentUser(account);
       tokenFromAccount(currentUser).then((token) async {

--- a/lib/Map.dart
+++ b/lib/Map.dart
@@ -34,7 +34,7 @@ class Direction extends StatelessWidget {
 }
 
 class Map extends StatelessWidget {
-  BorderRadiusGeometry radius = BorderRadius.only(
+  final BorderRadiusGeometry radius = BorderRadius.only(
     topLeft: Radius.circular(24.0),
     topRight: Radius.circular(24.0),
   );

--- a/lib/Upcoming.dart
+++ b/lib/Upcoming.dart
@@ -5,7 +5,7 @@ import 'Map.dart';
 class Rider extends StatefulWidget {
   Rider({Key key, @required this.name}) : super(key: key);
 
-  String name;
+  final String name;
 
   @override
   _RiderState createState() => _RiderState();
@@ -55,8 +55,8 @@ class Location extends StatefulWidget {
   Location({Key key, @required this.heading, @required this.location})
       : super(key: key);
 
-  String heading;
-  String location;
+  final String heading;
+  final String location;
 
   @override
   _LocationState createState() => _LocationState();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:http/http.dart';
 import 'dart:io';
-import 'dart:convert' as convert;
 import 'Login.dart';
 
 void main() {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,7 +5,6 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:carriage/main.dart';
@@ -15,16 +14,6 @@ void main() {
     // Build our app and trigger a frame.
     await tester.pumpWidget(MyApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(1 + 1, 2);
   });
 }


### PR DESCRIPTION
### Summary <!-- Required -->

Some tweaks to ensure that linter and test can pass.

- Remove test generated by flutter init. The test asserted some dummy content that is no longer on the screen.
- Add `final` to class fields to respect `flutter analyze`.
- Remove unused imports.

### Test Plan <!-- Required -->

`flutter analyze` and `flutter test` failures are no longer silenced in CI. See logs.
