### PR TITLE
Rides page backend integration

### DIFF
--- a/lib/Home.dart
+++ b/lib/Home.dart
@@ -49,13 +49,10 @@ class _HomeState extends State<Home> {
 
   int _selectedIndex = RIDES;
   List<FutureRide> rides;
-  String _name;
 
   @override
   void initState() {
     super.initState();
-    // Fetch name of user
-    _name = "Chris";
   }
 
   void _onItemTapped(int index) {

--- a/lib/Home.dart
+++ b/lib/Home.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'Rides.dart';
 import 'Upcoming.dart';
 import 'Login.dart';
 import 'Profile.dart';
@@ -6,7 +7,7 @@ import 'Profile.dart';
 class Greeting extends StatelessWidget {
   final String name;
 
-  Greeting({@required this.name});
+  Greeting(this.name);
 
   @override
   Widget build(BuildContext context) {
@@ -47,7 +48,7 @@ class _HomeState extends State<Home> {
   static const int PROFILE = 2;
 
   int _selectedIndex = RIDES;
-  List<UpcomingRide> rides;
+  List<FutureRide> rides;
   String _name;
 
   @override
@@ -55,8 +56,6 @@ class _HomeState extends State<Home> {
     super.initState();
     // Fetch name of user
     _name = "Chris";
-    // TODO: fetch info about rides
-    rides = [UpcomingRide(startTime: DateTime.now())];
   }
 
   void _onItemTapped(int index) {
@@ -64,63 +63,7 @@ class _HomeState extends State<Home> {
       _selectedIndex = index;
     });
   }
-
-  Widget _ride(BuildContext context, int index) {
-    return UpcomingRide();
-  }
-
-  Widget _ridesPage(BuildContext context) {
-    return Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Greeting(name: _name),
-          LeftSubheading(heading: 'Upcoming Ride'),
-          Center(
-              child: Column(
-                children: <Widget>[
-                  CurrentRide(),
-                ],
-              )),
-          SizedBox(height: 16.0),
-          LeftSubheading(heading: 'Today\'s Schedule'),
-          Flexible(
-            child: ListView.separated(
-              itemCount: 3,
-              itemBuilder: _ride,
-              separatorBuilder: (BuildContext context, int index) => Divider(),
-              padding: EdgeInsets.only(left: 24.0, right: 24.0, bottom: 5.0),
-            ),
-          ),
-        ]);
-  }
-
-  Widget _noRidesLeftPage (BuildContext context) {
-    return Column (
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Greeting(name: _name),
-        SizedBox(height: 195),
-        Center (
-            child: Column (
-              children: <Widget>[
-                Image(
-                  image: AssetImage('assets/images/steeringWheel@3x.png'),
-                  width: MediaQuery.of(context).size.width * 0.2,
-                  height: MediaQuery.of(context).size.width * 0.2,
-                ),
-                SizedBox(height: 22),
-                Text(
-                  'Congratulations! You are done for the day. \n'
-                      'Come back tomorrow!',
-                  textAlign: TextAlign.center,
-                )
-              ],
-            )
-        ),
-      ],
-    );
-  }
-
+  
   Widget _profilePage(BuildContext context) {
     return Column (
       children: <Widget>[
@@ -135,10 +78,7 @@ class _HomeState extends State<Home> {
   Widget getPage(BuildContext context, int index) {
     switch (index) {
       case (RIDES):
-        if (rides.length == 0) {
-          return _noRidesLeftPage(context);
-        }
-        return _ridesPage(context);
+        return Rides();
       case (HISTORY):
         return Column(
           children: <Widget>[

--- a/lib/Ride.dart
+++ b/lib/Ride.dart
@@ -1,0 +1,46 @@
+import 'dart:core';
+
+class Ride {
+  final String id;
+  final String startLocation;
+  final String endLocation;
+  final DateTime startTime;
+  final DateTime endTime;
+  final bool isScheduled;
+  final List<String> riderId;
+  // can be null
+  final List<String> driverId;
+  // can be null
+  final List<String> repeatsOn;
+
+  Ride({
+    this.id,
+    this.startLocation,
+    this.endLocation,
+    this.isScheduled,
+    this.riderId,
+    this.driverId,
+    this.endTime,
+    this.repeatsOn,
+    this.startTime});
+
+  factory Ride.fromJson(Map<String,dynamic> json) {
+    return Ride(
+      id: json['id'],
+      startLocation: json['startLocation'],
+      endLocation: json['endLocation'],
+      startTime: DateTime.parse(json['startTime']),
+      endTime: DateTime.parse(json['endTime']),
+      isScheduled: json['isScheduled'],
+      riderId: json['riderId'],
+      driverId: getOrNull(json,'driverId'),
+      repeatsOn: getOrNull(json,'repeatsOn')
+    );
+  }
+
+  // TODO: hi chris where do i move this to
+  static dynamic getOrNull(Map<String,dynamic> map, String key) {
+    return map.containsKey(key) ? map[key] : null;
+  }
+
+}

--- a/lib/Ride.dart
+++ b/lib/Ride.dart
@@ -26,15 +26,15 @@ class Ride {
 
   factory Ride.fromJson(Map<String,dynamic> json) {
     return Ride(
-      id: getOrNull(json,'id'),
+      id: json['id'],
       startLocation: json['startLocation'],
       endLocation: json['endLocation'],
       startTime: DateTime.parse(json['startTime']),
       endTime: DateTime.parse(json['endTime']),
       isScheduled: json['isScheduled'],
-      riderId: json['riderId'],
-      driverId: json['driverId'],
-      repeatsOn: getOrNull(json,'repeatsOn'),
+      riderId: json['riderID'],
+      driverId: (json['driverID'] as List<dynamic>).cast<String>().toList(),
+      // repeatsOn: getOrNull(json,'repeatsOn'),
     );
   }
 }

--- a/lib/Ride.dart
+++ b/lib/Ride.dart
@@ -26,18 +26,21 @@ class Ride {
 
   factory Ride.fromJson(Map<String,dynamic> json) {
     return Ride(
-      id: json['id'],
+      id: getOrNull(json,'id'),
       startLocation: json['startLocation'],
       endLocation: json['endLocation'],
       startTime: DateTime.parse(json['startTime']),
       endTime: DateTime.parse(json['endTime']),
       isScheduled: json['isScheduled'],
       riderId: json['riderId'],
-      driverId: getOrNull(json,'driverId'),
-      repeatsOn: getOrNull(json,'repeatsOn')
+      driverId: json['driverId'],
+      repeatsOn: getOrNull(json,'repeatsOn'),
     );
   }
 }
-dynamic getOrNull(Map<String,dynamic> map, String key) {
-  return map.containsKey(key) ? map[key] : null;
+dynamic id(x) => x;
+dynamic getOrNull<T>(Map<String,dynamic> map, String key, {dynamic parse(T s) = id}) {
+  var x = map.containsKey(key) ? map[key] : null;
+  if(x == null) return null;
+  return parse(x);
 }

--- a/lib/Ride.dart
+++ b/lib/Ride.dart
@@ -32,15 +32,15 @@ class Ride {
       startTime: DateTime.parse(json['startTime']),
       endTime: DateTime.parse(json['endTime']),
       isScheduled: json['isScheduled'],
-      riderId: json['riderID'],
-      driverId: (json['driverID'] as List<dynamic>).cast<String>().toList(),
-      // repeatsOn: getOrNull(json,'repeatsOn'),
+      riderId: (json['riderID'] as List<dynamic>).cast<String>().toList(),
+      driverId: (json['driverID'] as List<dynamic>)?.cast<String>()?.toList() ?? [],
+      repeatsOn: getOrNull(json,'repeatsOn', parse: (e) => (e as List<dynamic>).cast<String>().toList())
     );
   }
 }
-dynamic id(x) => x;
-dynamic getOrNull<T>(Map<String,dynamic> map, String key, {dynamic parse(T s) = id}) {
+T getOrNull<T>(Map<String,dynamic> map, String key, {T parse(dynamic s)}) {
   var x = map.containsKey(key) ? map[key] : null;
   if(x == null) return null;
+  if(parse == null) return x;
   return parse(x);
 }

--- a/lib/Ride.dart
+++ b/lib/Ride.dart
@@ -37,10 +37,7 @@ class Ride {
       repeatsOn: getOrNull(json,'repeatsOn')
     );
   }
-
-  // TODO: hi chris where do i move this to
-  static dynamic getOrNull(Map<String,dynamic> map, String key) {
-    return map.containsKey(key) ? map[key] : null;
-  }
-
+}
+dynamic getOrNull(Map<String,dynamic> map, String key) {
+  return map.containsKey(key) ? map[key] : null;
 }

--- a/lib/RideSummary.dart
+++ b/lib/RideSummary.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'Ride.dart';
 import 'Upcoming.dart';
 import 'Home.dart';
 import 'package:intl/intl.dart';
@@ -194,12 +195,21 @@ class RideSummary extends StatefulWidget {
 
 class _RideSummaryState extends State<RideSummary> {
   String _name;
+  Ride _currentRide;
 
   @override
   void initState() {
     super.initState();
-    // Fetch name of user
+    // TODO: placeholder
     _name = "Chris";
+    _currentRide = new Ride(
+        id: "1",
+        startLocation: "Teagle Hall",
+        endLocation: "RPCC",
+        startTime: new DateTime(2020,11,14),
+        endTime: new DateTime(2020,11,14),
+        riderId: [ "Terry Cruz", "Chris Hansen" ],
+      );
   }
 
 // TODO: ignore recent finished ride if it was too long ago
@@ -232,12 +242,12 @@ class _RideSummaryState extends State<RideSummary> {
     return Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          Greeting(name: _name),
+          Greeting(_name),
           Expanded(
               child: ListView(shrinkWrap: true, children: <Widget>[
             _recentRide(),
             LeftSubheading(heading: 'Upcoming Ride'),
-            Center(child: CurrentRide()),
+            Center(child: CurrentRide(_currentRide)),
             Padding(
                 padding: EdgeInsets.only(top: 36.0, bottom: 24.0),
                 child: DriverStats())

--- a/lib/Rides.dart
+++ b/lib/Rides.dart
@@ -1,12 +1,11 @@
 import 'dart:convert';
-import 'dart:io';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'Home.dart';
 import 'Ride.dart';
 import 'Upcoming.dart';
-import 'package:http/http.dart' as http;
-import 'app_config.dart';
+// import 'dart:io';
+// import 'package:intl/intl.dart';
+// import 'package:http/http.dart' as http;
 
 // Data for Rides page
 class _RideData {

--- a/lib/Rides.dart
+++ b/lib/Rides.dart
@@ -9,12 +9,8 @@ class Rides extends StatefulWidget {
 }
 
 class _RidesState extends State<Rides> {
-
   List<Ride> _rides;
-  Ride _currentRide = 
-    new Ride(
-      startTime: new DateTime(2020,11,14)
-    );
+  Ride _currentRide = new Ride(startTime: new DateTime(2020, 11, 14));
 
   @override
   void initState() {
@@ -25,17 +21,18 @@ class _RidesState extends State<Rides> {
         id: "1",
         startLocation: "Teagle Hall",
         endLocation: "RPCC",
-        startTime: new DateTime(2020,11,14),
-        endTime: new DateTime(2020,11,14),
-        riderId: [ "Terry Cruz", "Chris Hansen" ],
+        startTime: new DateTime(2020, 11, 14),
+        endTime: new DateTime(2020, 11, 14),
+        riderId: ["Terry Cruz", "Chris Hansen"],
       ),
       new Ride(
         id: "2",
         startLocation: "Balch South",
         endLocation: "Gates Hall",
-        startTime: new DateTime(2020,11,14),
-        endTime: new DateTime(2020,11,14),
-        riderId: [ "Terry Cruz", "Chris Hansen" ],)
+        startTime: new DateTime(2020, 11, 14),
+        endTime: new DateTime(2020, 11, 14),
+        riderId: ["Terry Cruz", "Chris Hansen"],
+      )
     ];
   }
 
@@ -49,50 +46,44 @@ class _RidesState extends State<Rides> {
   }
 
   Widget _emptyPage(BuildContext context) {
-   return Column (
+    return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Greeting(getNameFromSharedStateSomewhere()),
         SizedBox(height: 195),
-        Center (
-            child: Column (
-              children: <Widget>[
-                Image(
-                  image: AssetImage('assets/images/steeringWheel@3x.png'),
-                  width: MediaQuery.of(context).size.width * 0.2,
-                  height: MediaQuery.of(context).size.width * 0.2,
-                ),
-                SizedBox(height: 22),
-                Text(
-                  'Congratulations! You are done for the day. \n'
-                      'Come back tomorrow!',
-                  textAlign: TextAlign.center,
-                )
-              ],
+        Center(
+            child: Column(
+          children: <Widget>[
+            Image(
+              image: AssetImage('assets/images/steeringWheel@3x.png'),
+              width: MediaQuery.of(context).size.width * 0.2,
+              height: MediaQuery.of(context).size.width * 0.2,
+            ),
+            SizedBox(height: 22),
+            Text(
+              'Congratulations! You are done for the day. \n'
+              'Come back tomorrow!',
+              textAlign: TextAlign.center,
             )
-        ),
+          ],
+        )),
       ],
     );
   }
-  
+
   @override
   Widget build(BuildContext context) {
-    
-      if (_rides.length == 0) {
-        return _emptyPage(context);
-      }
+    if (_rides.length == 0) {
+      return _emptyPage(context);
+    }
     return Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           Greeting(getNameFromSharedStateSomewhere()),
           LeftSubheading(heading: 'Upcoming Ride'),
-          // TODO: remove this john
           Center(
-              child: Column(
-                children: <Widget>[
-                  CurrentRide(_currentRide),
-                ],
-              )),
+            child: CurrentRide(_currentRide),
+          ),
           SizedBox(height: 16.0),
           LeftSubheading(heading: 'Today\'s Schedule'),
           Flexible(
@@ -106,4 +97,3 @@ class _RidesState extends State<Rides> {
         ]);
   }
 }
-

--- a/lib/Rides.dart
+++ b/lib/Rides.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -36,16 +37,19 @@ class _RidesState extends State<Rides> {
     final dateFormat = DateFormat("yyyy-MM-dd");
     // TODO: use real endpoint
     final response = await http
-        .get('localhost:3000/active-rides?date=${dateFormat.format(now)}');
+        .get(new Uri.http('localhost:3000','/active-rides',{"date":dateFormat.format(now)}));
     if (response.statusCode == 200) {
       List<dynamic> data = jsonDecode(response.body)["data"];
-      List<Ride> activeRides = data.map((e) => Ride.fromJson(e));
-      List<Ride> rides = activeRides
+      List<Ride> rides =
+          data.map((e) => Ride.fromJson(e))
           .where((e) => e.driverId.contains(widget.driverId))
           .toList()
           ..sort((a, b) => a.startTime.compareTo(b.startTime));
-      rides.removeAt(0);
-      Ride currentRide = rides[0];
+      Ride currentRide;
+      if(rides.length > 0) {
+        currentRide = rides[0];
+        rides.removeAt(0);
+      }
       var d = _RideData(rides,currentRide);
       return d;
     } else {

--- a/lib/Rides.dart
+++ b/lib/Rides.dart
@@ -16,7 +16,7 @@ class _RideData {
 
 class Rides extends StatefulWidget {
   // TODO: placeholder
-  String driverId = "test";
+  final String driverId = "test";
 
   @override
   _RidesState createState() => _RidesState();

--- a/lib/Rides.dart
+++ b/lib/Rides.dart
@@ -1,39 +1,56 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'Home.dart';
 import 'Ride.dart';
 import 'Upcoming.dart';
+import 'package:http/http.dart' as http;
+
+// Data for Rides page
+class _RideData {
+  List<Ride> rides;
+  Ride currentRide;
+  _RideData(this.rides, this.currentRide);
+}
 
 class Rides extends StatefulWidget {
+  // TODO: placeholder
+  String driverId = "test";
+
   @override
   _RidesState createState() => _RidesState();
 }
 
 class _RidesState extends State<Rides> {
-  List<Ride> _rides;
-  Ride _currentRide = new Ride(startTime: new DateTime(2020, 11, 14));
+  Future<_RideData> rideData;
 
   @override
   void initState() {
     super.initState();
-    // TODO: placeholder data
-    _rides = [
-      new Ride(
-        id: "1",
-        startLocation: "Teagle Hall",
-        endLocation: "RPCC",
-        startTime: new DateTime(2020, 11, 14),
-        endTime: new DateTime(2020, 11, 14),
-        riderId: ["Terry Cruz", "Chris Hansen"],
-      ),
-      new Ride(
-        id: "2",
-        startLocation: "Balch South",
-        endLocation: "Gates Hall",
-        startTime: new DateTime(2020, 11, 14),
-        endTime: new DateTime(2020, 11, 14),
-        riderId: ["Terry Cruz", "Chris Hansen"],
-      )
-    ];
+    rideData = _fetchRides();
+  }
+
+  Future<_RideData> _fetchRides() async {
+    var now = DateTime.now();
+    final dateFormat = DateFormat("yyyy-MM-dd");
+    // TODO: use real endpoint
+    final response = await http
+        .get('localhost:3000/active-rides?date=${dateFormat.format(now)}');
+    if (response.statusCode == 200) {
+      List<dynamic> data = jsonDecode(response.body)["data"];
+      List<Ride> activeRides = data.map((e) => Ride.fromJson(e));
+      List<Ride> rides = activeRides
+          .where((e) => e.driverId.contains(widget.driverId))
+          .toList()
+          ..sort((a, b) => a.startTime.compareTo(b.startTime));
+      rides.removeAt(0);
+      Ride currentRide = rides[0];
+      var d = _RideData(rides,currentRide);
+      return d;
+    } else {
+      throw Exception('Failed to load rides.');
+    }
   }
 
   // TODO: replace this when name is stored somewhere
@@ -41,15 +58,14 @@ class _RidesState extends State<Rides> {
     return "Chris";
   }
 
-  Widget _rideBuild(BuildContext context, int index) {
-    return FutureRide(_rides[index]);
+  Widget _futureRide(BuildContext context, _RideData d, int index) {
+    return FutureRide(d.rides[index]);
   }
 
   Widget _emptyPage(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Greeting(getNameFromSharedStateSomewhere()),
         SizedBox(height: 195),
         Center(
             child: Column(
@@ -71,29 +87,47 @@ class _RidesState extends State<Rides> {
     );
   }
 
+  Widget _mainPage(BuildContext context, _RideData data) {
+    return Column(children: <Widget>[
+      LeftSubheading(heading: 'Upcoming Ride'),
+      Center(
+        child: CurrentRide(data.currentRide),
+      ),
+      SizedBox(height: 16.0),
+      LeftSubheading(heading: 'Today\'s Schedule'),
+      Flexible(
+        child: ListView.separated(
+          itemCount: data.rides.length,
+          itemBuilder: (BuildContext c, int index) =>
+              _futureRide(c, data, index),
+          separatorBuilder: (BuildContext context, int index) => Divider(),
+          padding: EdgeInsets.only(left: 24.0, right: 24.0, bottom: 5.0),
+        ),
+      )
+    ]);
+  }
+
   @override
   Widget build(BuildContext context) {
-    if (_rides.length == 0) {
-      return _emptyPage(context);
-    }
     return Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           Greeting(getNameFromSharedStateSomewhere()),
-          LeftSubheading(heading: 'Upcoming Ride'),
-          Center(
-            child: CurrentRide(_currentRide),
-          ),
-          SizedBox(height: 16.0),
-          LeftSubheading(heading: 'Today\'s Schedule'),
-          Flexible(
-            child: ListView.separated(
-              itemCount: _rides.length,
-              itemBuilder: _rideBuild,
-              separatorBuilder: (BuildContext context, int index) => Divider(),
-              padding: EdgeInsets.only(left: 24.0, right: 24.0, bottom: 5.0),
-            ),
-          ),
+          FutureBuilder<_RideData>(
+              future: rideData,
+              builder: (context, snapshot) {
+                if (snapshot.hasData) {
+                  if (snapshot.data.rides.length == 0) {
+                    return _emptyPage(context);
+                  } else {
+                    return _mainPage(context, snapshot.data);
+                  }
+                } else if (snapshot.hasError) {
+                  // TODO: placeholder error response
+                  return Text("${snapshot.error}");
+                }
+                return CircularProgressIndicator();
+              })
         ]);
   }
 }

--- a/lib/Rides.dart
+++ b/lib/Rides.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'Home.dart';
+import 'Ride.dart';
+import 'Upcoming.dart';
+
+class Rides extends StatefulWidget {
+  @override
+  _RidesState createState() => _RidesState();
+}
+
+class _RidesState extends State<Rides> {
+
+  List<Ride> _rides;
+  Ride _currentRide = 
+    new Ride(
+      startTime: new DateTime(2020,11,14)
+    );
+
+  @override
+  void initState() {
+    super.initState();
+    // TODO: placeholder data
+    _rides = [
+      new Ride(
+        id: "1",
+        startLocation: "Teagle Hall",
+        endLocation: "RPCC",
+        startTime: new DateTime(2020,11,14),
+        endTime: new DateTime(2020,11,14),
+        riderId: [ "Terry Cruz", "Chris Hansen" ],
+      ),
+      new Ride(
+        id: "2",
+        startLocation: "Balch South",
+        endLocation: "Gates Hall",
+        startTime: new DateTime(2020,11,14),
+        endTime: new DateTime(2020,11,14),
+        riderId: [ "Terry Cruz", "Chris Hansen" ],)
+    ];
+  }
+
+  // TODO: replace this when name is stored somewhere
+  String getNameFromSharedStateSomewhere() {
+    return "Chris";
+  }
+
+  Widget _rideBuild(BuildContext context, int index) {
+    return FutureRide(_rides[index]);
+  }
+
+  Widget _emptyPage(BuildContext context) {
+   return Column (
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Greeting(getNameFromSharedStateSomewhere()),
+        SizedBox(height: 195),
+        Center (
+            child: Column (
+              children: <Widget>[
+                Image(
+                  image: AssetImage('assets/images/steeringWheel@3x.png'),
+                  width: MediaQuery.of(context).size.width * 0.2,
+                  height: MediaQuery.of(context).size.width * 0.2,
+                ),
+                SizedBox(height: 22),
+                Text(
+                  'Congratulations! You are done for the day. \n'
+                      'Come back tomorrow!',
+                  textAlign: TextAlign.center,
+                )
+              ],
+            )
+        ),
+      ],
+    );
+  }
+  
+  @override
+  Widget build(BuildContext context) {
+    
+      if (_rides.length == 0) {
+        return _emptyPage(context);
+      }
+    return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Greeting(getNameFromSharedStateSomewhere()),
+          LeftSubheading(heading: 'Upcoming Ride'),
+          // TODO: remove this john
+          Center(
+              child: Column(
+                children: <Widget>[
+                  CurrentRide(_currentRide),
+                ],
+              )),
+          SizedBox(height: 16.0),
+          LeftSubheading(heading: 'Today\'s Schedule'),
+          Flexible(
+            child: ListView.separated(
+              itemCount: _rides.length,
+              itemBuilder: _rideBuild,
+              separatorBuilder: (BuildContext context, int index) => Divider(),
+              padding: EdgeInsets.only(left: 24.0, right: 24.0, bottom: 5.0),
+            ),
+          ),
+        ]);
+  }
+}
+

--- a/lib/Rides.dart
+++ b/lib/Rides.dart
@@ -44,9 +44,8 @@ class _RidesState extends State<Rides> {
         "endLocation": "Rhodes",
         "startTime": "2020-01-02T14:00:00.000Z",
         "endTime": "2020-01-02T16:00:00.000Z",
-        "riderID": "61274c50-819f-11ea-8b9d-c3580ef31720",
-        "riderID": null,
-        "repeatsOn": null,
+        "riderID": ["123"],
+        "repeatsOn": ["Monday","Wednesday"],
         "driverID": ["test"]
     },
     {
@@ -56,7 +55,7 @@ class _RidesState extends State<Rides> {
         "startTime": "2020-01-02T05:00:00.000Z",
         "endTime": "2020-01-02T00:00:00.000Z",
         "isScheduled": false,
-        "riderID": null,
+        "riderID": ["abc"],
         "repeatsOn": null,
         "driverID": ["test"]
     },
@@ -67,9 +66,8 @@ class _RidesState extends State<Rides> {
         "startTime": "2020-01-02T05:00:00.000Z",
         "endTime": "2020-01-02T00:00:00.000Z",
         "isScheduled": false,
-        "riderID": null,
-        "repeatsOn": null,
-        "driverID": ["bad"]
+        "riderID": ["123"],
+        "driverID": null
     }
   ]
 }''';

--- a/lib/Rides.dart
+++ b/lib/Rides.dart
@@ -23,14 +23,10 @@ class Rides extends StatefulWidget {
 }
 
 class _RidesState extends State<Rides> {
-  Future<_RideData> rideData;
-
   @override
   void initState() {
     super.initState();
-    rideData = _fetchRides();
   }
-
   Future<_RideData> _fetchRides() async {
     // TODO: temporary placeholder response for testing
     // replace when backend sends all fields
@@ -179,7 +175,7 @@ class _RidesState extends State<Rides> {
           Greeting(getNameFromSharedStateSomewhere()),
           Expanded(
               child: FutureBuilder<_RideData>(
-                  future: rideData,
+                  future: _fetchRides(),
                   builder: (context, snapshot) {
                     if (snapshot.hasData) {
                       if (snapshot.data.rides.length == 0) {

--- a/lib/Upcoming.dart
+++ b/lib/Upcoming.dart
@@ -157,7 +157,7 @@ class CurrentRide extends StatefulWidget {
         super(key: key);
 
   final DateTime date;
-  // TODO: placeholder values
+  // TODO: still placeholder values
   final List<_StopData> stops = [
     new _StopData('Terry Cruz', 'Cascadilla', StopType.pickup),
     new _StopData('Chris Hansen', 'Rhodes', StopType.dropoff)

--- a/lib/Upcoming.dart
+++ b/lib/Upcoming.dart
@@ -9,6 +9,8 @@ class Rider extends StatelessWidget {
 
   final String riderName;
   final String injury;
+  // TODO: placeholder
+  final String img = 'assets/images/terry.jpg';
 
   @override
   Widget build(BuildContext context) {
@@ -16,7 +18,7 @@ class Rider extends StatelessWidget {
       child: Row(
         children: <Widget>[
           CircleAvatar(
-            backgroundImage: AssetImage('assets/images/terry.jpg'),
+            backgroundImage: AssetImage(img),
             radius: 25,
           ),
           SizedBox(width: 12.0),
@@ -25,13 +27,15 @@ class Rider extends StatelessWidget {
             children: <Widget>[
               Text('$riderName',
                   style: TextStyle(fontSize: 12, letterSpacing: 0.23)),
-              // TODO: check if we can update sdk version for this
-              if (injury != null)
-                Text('Needs: $injury',
+              () {
+              if (injury != null) {
+                return Text('Needs: $injury',
                     style: TextStyle(
                         color: Color.fromRGBO(142, 142, 147, 1),
                         fontSize: 10,
-                        letterSpacing: 0.19))
+                        letterSpacing: 0.19));
+              } else return new Container();
+              }()
             ],
           )
         ],
@@ -111,15 +115,16 @@ class Time extends StatelessWidget {
 class Summary extends StatefulWidget {
   Summary({Key key}) : super(key: key);
 
-
   @override
   SummaryState createState() => SummaryState();
 }
+
 class SummaryState extends State<Summary> {
-  
-  @override void initState() {
+  @override
+  void initState() {
     super.initState();
   }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -136,6 +141,16 @@ class SummaryState extends State<Summary> {
   }
 }
 
+enum StopType { pickup, dropoff }
+
+// Data for ride stops for CurrentRide widget
+class _StopData {
+  String name;
+  String location;
+  StopType stopType;
+  _StopData(this.name, this.location, this.stopType);
+}
+
 class CurrentRide extends StatefulWidget {
   CurrentRide(Ride ride, {Key key})
       : date = ride.startTime,
@@ -143,9 +158,9 @@ class CurrentRide extends StatefulWidget {
 
   final DateTime date;
   // TODO: placeholder values
-  final List<List<String>> riders = [
-    ['Terry Cruz', 'Pick up', 'Cascadilla'],
-    ['Chris Hansen', 'Drop off', 'Rhodes']
+  final List<_StopData> stops = [
+    new _StopData('Terry Cruz', 'Cascadilla', StopType.pickup),
+    new _StopData('Chris Hansen', 'Rhodes', StopType.dropoff)
   ];
 
   @override
@@ -158,6 +173,17 @@ class _CurrentRideState extends State<CurrentRide> {
   void initState() {
     super.initState();
     // Will need to fetch data here
+  }
+
+  String _stopLabelText(StopType t) {
+    switch (t) {
+      case StopType.pickup:
+        return 'Pick up';
+      case StopType.dropoff:
+        return 'Drop off';
+    }
+    // TODO: maybe change if we have a convention for this?
+    throw new Exception("impossible");
   }
 
   @override
@@ -188,64 +214,64 @@ class _CurrentRideState extends State<CurrentRide> {
                   spreadRadius: 1.0)
             ],
           ),
-          child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Date(widget.date),
-                Time(TimeOfDay.fromDateTime(widget.date)),
-                Padding(
-                  padding: EdgeInsets.only(left: 24),
-                  child: ListView.builder(
-                      physics: NeverScrollableScrollPhysics(),
-                      shrinkWrap: true,
-                      itemCount: widget.riders.length,
-                      itemBuilder: (BuildContext context, int index) {
-                        return Padding(
-                          padding: EdgeInsets.only(top: 0, bottom: 12),
-                          child: Row(
-                            children: <Widget>[
-                              Expanded(
-                                child: Rider(widget.riders[index][0]),
-                              ),
-                              Expanded(
-                                child: Padding(
-                                  padding: EdgeInsets.only(left: 12),
-                                  child: Location(widget.riders[index][1],
-                                      widget.riders[index][2]),
-                                ),
-                              )
-                            ],
+          child:
+              Column(crossAxisAlignment: CrossAxisAlignment.start, children: <
+                  Widget>[
+            Date(widget.date),
+            Time(TimeOfDay.fromDateTime(widget.date)),
+            Padding(
+              padding: EdgeInsets.only(left: 24),
+              child: ListView.builder(
+                  physics: NeverScrollableScrollPhysics(),
+                  shrinkWrap: true,
+                  itemCount: widget.stops.length,
+                  itemBuilder: (BuildContext context, int index) {
+                    return Padding(
+                      padding: EdgeInsets.only(top: 0, bottom: 12),
+                      child: Row(
+                        children: <Widget>[
+                          Expanded(
+                            child: Rider(widget.stops[index].name),
                           ),
-                        );
-                      }),
-                ),
-                Visibility(
-                  visible: _starting,
-                  child: Center(
-                    child: Padding(
-                      padding:
-                          EdgeInsets.only(top: btnPadding, bottom: btnPadding),
-                      child: ButtonTheme(
-                        minWidth: btnWidth,
-                        height: btnHeight,
-                        child: RaisedButton(
-                          onPressed: () {
-                            Navigator.of(context)
-                                .push(MaterialPageRoute(builder: (context) {
-                              return Map();
-                            }));
-                          },
-                          shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(3)),
-                          color: Theme.of(context).accentColor,
-                          child: Text('START',
-                              style: TextStyle(color: Colors.white)),
-                        ),
+                          Expanded(
+                            child: Padding(
+                              padding: EdgeInsets.only(left: 12),
+                              child: Location(
+                                  _stopLabelText(widget.stops[index].stopType),
+                                  widget.stops[index].location),
+                            ),
+                          )
+                        ],
                       ),
+                    );
+                  }),
+            ),
+            Visibility(
+              visible: _starting,
+              child: Center(
+                child: Padding(
+                  padding: EdgeInsets.only(top: btnPadding, bottom: btnPadding),
+                  child: ButtonTheme(
+                    minWidth: btnWidth,
+                    height: btnHeight,
+                    child: RaisedButton(
+                      onPressed: () {
+                        Navigator.of(context)
+                            .push(MaterialPageRoute(builder: (context) {
+                          return Map();
+                        }));
+                      },
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(3)),
+                      color: Theme.of(context).accentColor,
+                      child:
+                          Text('START', style: TextStyle(color: Colors.white)),
                     ),
                   ),
                 ),
-              ]),
+              ),
+            ),
+          ]),
         ),
       ),
     );
@@ -260,24 +286,16 @@ class FutureRide extends StatelessWidget {
 
   final DateTime date;
   final TimeOfDay time;
-
   // TODO: placeholder
-  List<String> somehowGetRiderImages() {
-    return ['assets/images/terry.jpg', 'assets/images/terry.jpg'];
-  }
-
-  // TODO: placeholder
-  List<String> somehowGetDestinations() {
-    return ["Fgafd", "Morrison", "PSB", "Gates"];
-  }
+  final List<String> destinations = ["Fgafd", "Morrison", "PSB", "Gates"];
+  final List<String> riderImgs = [
+    'assets/images/terry.jpg',
+    'assets/images/terry.jpg'
+  ];
 
   @override
   Widget build(BuildContext context) {
     double _width = MediaQuery.of(context).size.width - 48;
-
-    var _riderImgs = somehowGetRiderImages();
-    var _destinations = somehowGetDestinations();
-
     return Container(
       constraints: BoxConstraints(
           minWidth: _width, maxWidth: _width, minHeight: _width / 2),
@@ -317,10 +335,10 @@ class FutureRide extends StatelessWidget {
                             spacing: 12,
                             runSpacing: 12,
                             children:
-                                List.generate(_riderImgs.length, (int index) {
+                                List.generate(riderImgs.length, (int index) {
                               return CircleAvatar(
                                 radius: 25,
-                                backgroundImage: AssetImage(_riderImgs[index]),
+                                backgroundImage: AssetImage(riderImgs[index]),
                               );
                             }),
                           ))
@@ -331,7 +349,7 @@ class FutureRide extends StatelessWidget {
                   flex: 146,
                   child: Column(
                     children: <Widget>[
-                      Route(destinations: _destinations),
+                      Route(destinations: destinations),
                       SizedBox(height: 24)
                     ],
                   ),

--- a/lib/Upcoming.dart
+++ b/lib/Upcoming.dart
@@ -1,27 +1,14 @@
 import 'dart:core';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'Map.dart';
+import 'Ride.dart';
 
-class Rider extends StatefulWidget {
-  Rider({Key key, @required this.name}) : super(key: key);
+class Rider extends StatelessWidget {
+  Rider(this.riderName, {Key key, this.injury}) : super(key: key);
 
-  final String name;
-
-  @override
-  _RiderState createState() => _RiderState();
-}
-
-class _RiderState extends State<Rider> {
-  String _riderName;
-  String _injury;
-
-  @override
-  void initState() {
-    super.initState();
-    // Fetch the Rider and their Injury from API
-    _riderName = widget.name;
-    _injury = "Wheelchair";
-  }
+  final String riderName;
+  final String injury;
 
   @override
   Widget build(BuildContext context) {
@@ -36,13 +23,15 @@ class _RiderState extends State<Rider> {
           Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
-              Text('$_riderName',
+              Text('$riderName',
                   style: TextStyle(fontSize: 12, letterSpacing: 0.23)),
-              Text('Needs: $_injury',
-                  style: TextStyle(
-                      color: Color.fromRGBO(142, 142, 147, 1),
-                      fontSize: 10,
-                      letterSpacing: 0.19))
+              // TODO: check if we can update sdk version for this
+              if (injury != null)
+                Text('Needs: $injury',
+                    style: TextStyle(
+                        color: Color.fromRGBO(142, 142, 147, 1),
+                        fontSize: 10,
+                        letterSpacing: 0.19))
             ],
           )
         ],
@@ -51,26 +40,11 @@ class _RiderState extends State<Rider> {
   }
 }
 
-class Location extends StatefulWidget {
-  Location({Key key, @required this.heading, @required this.location})
-      : super(key: key);
-
+class Location extends StatelessWidget {
   final String heading;
   final String location;
 
-  @override
-  _LocationState createState() => _LocationState();
-}
-
-class _LocationState extends State<Location> {
-  String _location;
-
-  @override
-  void initState() {
-    super.initState();
-    // Fetch Pickup or Drop off Location
-    _location = widget.location;
-  }
+  Location(this.heading, this.location, {Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -79,13 +53,13 @@ class _LocationState extends State<Location> {
         Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            Text('${widget.heading}',
+            Text('$heading',
                 style: TextStyle(
                     fontSize: 12,
                     color: Theme.of(context).accentColor,
                     letterSpacing: 0)),
             SizedBox(height: 4),
-            Text('$_location',
+            Text('$location',
                 style: TextStyle(
                     fontSize: 17,
                     fontWeight: FontWeight.bold,
@@ -97,28 +71,18 @@ class _LocationState extends State<Location> {
   }
 }
 
-class Date extends StatefulWidget {
-  Date({Key key}) : super(key: key);
+class Date extends StatelessWidget {
+  Date(this.date, {Key key}) : super(key: key);
 
-  @override
-  _DateState createState() => _DateState();
-}
+  final DateTime date;
 
-class _DateState extends State<Date> {
-  String _date;
-
-  @override
-  void initState() {
-    super.initState();
-    // Fetch date
-    _date = "Nov 12";
-  }
+  final DateFormat format = new DateFormat('MMM d');
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: EdgeInsets.only(left: 24.0, top: 12.0),
-      child: Text('$_date',
+      child: Text(format.format(date),
           style: TextStyle(
               fontSize: 17,
               color: Theme.of(context).accentColor,
@@ -127,42 +91,27 @@ class _DateState extends State<Date> {
   }
 }
 
-class Time extends StatefulWidget {
-  Time({Key key}) : super(key: key);
+class Time extends StatelessWidget {
+  Time(this.time, {Key key}) : super(key: key);
 
-  @override
-  _TimeState createState() => _TimeState();
-}
-
-class _TimeState extends State<Time> {
-  String _time;
-
-  @override
-  void initState() {
-    super.initState();
-    // Fetch start time
-    _time = "10:12";
-  }
+  final TimeOfDay time;
 
   @override
   Widget build(BuildContext context) {
+    final localizations = MaterialLocalizations.of(context);
     return Padding(
       padding: EdgeInsets.only(left: 24.0, top: 12.0),
-      child: Text('$_time',
+      child: Text(localizations.formatTimeOfDay(time),
           style: TextStyle(
               fontSize: 34, fontWeight: FontWeight.bold, letterSpacing: 0.37)),
     );
   }
 }
 
-class Summary extends StatefulWidget {
+// TODO make stateful again
+class Summary extends StatelessWidget {
   Summary({Key key}) : super(key: key);
 
-  @override
-  _SummaryState createState() => _SummaryState();
-}
-
-class _SummaryState extends State<Summary> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -180,7 +129,16 @@ class _SummaryState extends State<Summary> {
 }
 
 class CurrentRide extends StatefulWidget {
-  CurrentRide({Key key, DateTime startTime}) : super(key: key);
+  CurrentRide(Ride ride, {Key key})
+      : date = ride.startTime,
+        super(key: key);
+
+  final DateTime date;
+  // TODO: placeholder values
+  final List<List<String>> riders = [
+    ['Terry Cruz', 'Pick up', 'Cascadilla'],
+    ['Chris Hansen', 'Drop off', 'Rhodes']
+  ];
 
   @override
   _CurrentRideState createState() => _CurrentRideState();
@@ -188,11 +146,6 @@ class CurrentRide extends StatefulWidget {
 
 class _CurrentRideState extends State<CurrentRide> {
   bool _starting = false;
-  List<List<String>> _riders = [
-    ['Terry Cruz', 'Pick up', 'Cascadilla'],
-    ['Chris Hansen', 'Drop off', 'Rhodes']
-  ];
-
   @override
   void initState() {
     super.initState();
@@ -230,28 +183,27 @@ class _CurrentRideState extends State<CurrentRide> {
           child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-                Date(),
-                Time(),
+                Date(widget.date),
+                Time(TimeOfDay.fromDateTime(widget.date)),
                 Padding(
                   padding: EdgeInsets.only(left: 24),
                   child: ListView.builder(
                       physics: NeverScrollableScrollPhysics(),
                       shrinkWrap: true,
-                      itemCount: _riders.length,
+                      itemCount: widget.riders.length,
                       itemBuilder: (BuildContext context, int index) {
                         return Padding(
                           padding: EdgeInsets.only(top: 0, bottom: 12),
                           child: Row(
                             children: <Widget>[
                               Expanded(
-                                child: Rider(name: _riders[index][0]),
+                                child: Rider(widget.riders[index][0]),
                               ),
                               Expanded(
                                 child: Padding(
                                   padding: EdgeInsets.only(left: 12),
-                                  child: Location(
-                                      heading: _riders[index][1],
-                                      location: _riders[index][2]),
+                                  child: Location(widget.riders[index][1],
+                                      widget.riders[index][2]),
                                 ),
                               )
                             ],
@@ -292,41 +244,31 @@ class _CurrentRideState extends State<CurrentRide> {
   }
 }
 
-class UpcomingRide extends StatefulWidget {
-  UpcomingRide({Key key, DateTime startTime}) : super(key: key);
+class FutureRide extends StatelessWidget {
+  FutureRide(Ride ride, {Key key})
+      : date = ride.startTime,
+        time = TimeOfDay.fromDateTime(ride.startTime),
+        super(key: key);
 
-  @override
-  _UpcomingRideState createState() => _UpcomingRideState();
-}
+  final DateTime date;
+  final TimeOfDay time;
 
-class _UpcomingRideState extends State<UpcomingRide> {
-  List<String> _riders;
-  List<String> _destinations;
+  // TODO: placeholder
+  List<String> somehowGetRiderImages() {
+    return ['assets/images/terry.jpg', 'assets/images/terry.jpg'];
+  }
 
-  @override
-  void initState() {
-    super.initState();
-    // Fetch Upcoming Information
-    _riders = [
-      'assets/images/terry.jpg',
-      'assets/images/terry.jpg',
-      'assets/images/terry.jpg'
-    ];
-    _destinations = [
-      "Fgafd",
-      "Morrison",
-      "PSB",
-      "Gates",
-      "Cascadilla",
-      "Rockefeller",
-      "gfa",
-      "hfa"
-    ];
+  // TODO: placeholder
+  List<String> somehowGetDestinations() {
+    return ["Fgafd", "Morrison", "PSB", "Gates"];
   }
 
   @override
   Widget build(BuildContext context) {
     double _width = MediaQuery.of(context).size.width - 48;
+
+    var _riderImgs = somehowGetRiderImages();
+    var _destinations = somehowGetDestinations();
 
     return Container(
       constraints: BoxConstraints(
@@ -358,8 +300,8 @@ class _UpcomingRideState extends State<UpcomingRide> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
-                      Date(),
-                      Time(),
+                      Date(date),
+                      Time(time),
                       Padding(
                           padding: EdgeInsets.only(
                               left: 24.0, top: 12.0, right: 24.0, bottom: 12.0),
@@ -367,10 +309,10 @@ class _UpcomingRideState extends State<UpcomingRide> {
                             spacing: 12,
                             runSpacing: 12,
                             children:
-                                List.generate(_riders.length, (int index) {
+                                List.generate(_riderImgs.length, (int index) {
                               return CircleAvatar(
                                 radius: 25,
-                                backgroundImage: AssetImage(_riders[index]),
+                                backgroundImage: AssetImage(_riderImgs[index]),
                               );
                             }),
                           ))
@@ -395,30 +337,19 @@ class _UpcomingRideState extends State<UpcomingRide> {
   }
 }
 
-class Route extends StatefulWidget {
+class Route extends StatelessWidget {
   const Route({Key key, @required this.destinations})
       : assert(destinations != null),
         super(key: key);
 
   final List<String> destinations;
 
-  @override
-  _RouteState createState() => _RouteState();
-}
-
-class _RouteState extends State<Route> {
-  @override
-  void initState() {
-    // TODO: implement initState
-    super.initState();
-  }
-
   bool _isFirst(int index) {
     return index == 0;
   }
 
   bool _isLast(int index) {
-    return index == widget.destinations.length - 1;
+    return index == destinations.length - 1;
   }
 
   Widget _buildLine(bool visible) {
@@ -446,7 +377,7 @@ class _RouteState extends State<Route> {
           ),
           Container(
             margin: const EdgeInsetsDirectional.only(start: 10.0),
-            child: Text(widget.destinations[index],
+            child: Text(destinations[index],
                 style: Theme.of(context).textTheme.display1),
           ),
         ],
@@ -459,7 +390,7 @@ class _RouteState extends State<Route> {
     return ListView.builder(
       shrinkWrap: true,
       physics: NeverScrollableScrollPhysics(),
-      itemCount: widget.destinations.length,
+      itemCount: destinations.length,
       itemBuilder: _buildVerticalHeader,
     );
   }

--- a/lib/Upcoming.dart
+++ b/lib/Upcoming.dart
@@ -108,10 +108,18 @@ class Time extends StatelessWidget {
   }
 }
 
-// TODO make stateful again
-class Summary extends StatelessWidget {
+class Summary extends StatefulWidget {
   Summary({Key key}) : super(key: key);
 
+
+  @override
+  SummaryState createState() => SummaryState();
+}
+class SummaryState extends State<Summary> {
+  
+  @override void initState() {
+    super.initState();
+  }
   @override
   Widget build(BuildContext context) {
     return Scaffold(


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is the first step towards hooking up the Rides page with the backend.

In doing so I moved the Rides page out Home and into its own widget in Rides.dart and cleaned up the ride widgets.
I also added a new Rides class to represent data about rides.

- [x] Replaced placeholder values in interface with Ride properties where possible.
- [x] Added code to fetch data from backend.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

Tested manually with Android emulator and placeholder json.

![Screenshot_1](https://user-images.githubusercontent.com/16505893/79672257-49ba8d80-819e-11ea-95c7-93d6693fe812.png)

### Notes <!-- Optional -->

Right now the Rides page makes the backend request in initState. In the future we probably want to make this shared state somewhere so we can be deliberate about when we fetch data.

There is code to make http requests to the backend but that is commented out for now because the backend doesn't output full json objects for active rides yet (some rides have fields missing, but Matt said the final version will have all fields). Instead, there is some placeholder json hardcoded in Rides.dart. 
