### PR TITLE
Info about breaks is displayed on profile

### DIFF
--- a/lib/Profile.dart
+++ b/lib/Profile.dart
@@ -16,7 +16,7 @@ class Break {
   Break(this.day, this.startTime, this.endTime);
 
   factory Break.fromJson(String day, Map<String, dynamic> json) {
-    return Break(day, json['startTime'], json['endTime']);
+    return Break(day, json['breakStart'], json['breakEnd']);
   }
 
   String toString() {
@@ -29,7 +29,7 @@ class Breaks {
   Breaks(this.breaks);
 
   factory Breaks.fromJson(Map<String, dynamic> json) {
-    List<Break> breaks;
+    List<Break> breaks = List<Break>();
     json.forEach((k, v) {
       breaks.add(Break.fromJson((abbrevToDay(k)), json[k]));
     });
@@ -54,7 +54,17 @@ class Breaks {
   }
 
   String toString() {
-    return breaks.fold("", (prev, element) => "$prev\n$element");
+    if (breaks.isEmpty) return "None";
+    else {
+      String str = "";
+      for (Break b in breaks) {
+        str += b.toString();
+        if (b != breaks.last) {
+          str += "\n";
+        }
+      }
+      return str;
+    }
   }
 }
 
@@ -68,15 +78,14 @@ class Driver {
   final String phoneNumber;
   final String email;
 
-  Driver(
-      {this.firstName,
-      this.lastName,
-      this.startTime,
-      this.endTime,
-      this.breaks,
-      this.vehicle,
-      this.phoneNumber,
-      this.email});
+  Driver({this.firstName,
+        this.lastName,
+        this.startTime,
+        this.endTime,
+        this.breaks,
+        this.vehicle,
+        this.phoneNumber,
+        this.email});
 
   factory Driver.fromJson(Map<String, dynamic> json) {
     return Driver(
@@ -84,8 +93,7 @@ class Driver {
         lastName: json['lastName'],
         startTime: json['startTime'],
         endTime: json['endTime'],
-        breaks:
-            (json['breaks'] == null) ? null : Breaks.fromJson(json['breaks']),
+        breaks: Breaks.fromJson(json['breaks']),
         vehicle: json['vehicle'],
         phoneNumber: json['phoneNumber'],
         email: json['email']);
@@ -323,7 +331,7 @@ class _InfoGroupState extends State<InfoGroup> {
               children: <Widget>[
                 Text(widget.title,
                     style:
-                        TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+                    TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
                 ListView.separated(
                     padding: EdgeInsets.all(0),
                     shrinkWrap: true,
@@ -385,7 +393,7 @@ class _EditProfileState extends State<EditProfile> {
               top: 18.0 + MediaQuery.of(context).padding.top,
             ),
             child:
-                Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+            Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
               Text('Edit Profile',
                   style: Theme.of(context).textTheme.headline5),
               SizedBox(height: 20),


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is the first step towards displaying info about a driver's breaks on the profile page

- [x] display empty breaks as "None"
- [x] display non-empty breaks

### Test Plan <!-- Required -->
Used Postman to set my breaks to empty, checked for "None"
![image](https://user-images.githubusercontent.com/60579411/81484656-52d6d180-9215-11ea-86d1-89e96ec9f9f9.png)

Used Postman to set my breaks to have a couple breaks, checked that it was displayed correctly and that page scrolled
![image](https://user-images.githubusercontent.com/60579411/81484658-579b8580-9215-11ea-982c-230275072a54.png)

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->
- Will update based on designs later if needed
<!--- List any important or subtle points, future considerations, or other items of note. -->
