### PR TITLE
Fix logout route

### DIFF
--- a/lib/Home.dart
+++ b/lib/Home.dart
@@ -4,7 +4,7 @@ import 'AuthProvider.dart';
 import 'LocationTracker.dart';
 import 'Rides.dart';
 import 'Upcoming.dart';
-import 'Login.dart';
+import 'main_common.dart';
 import 'Profile.dart';
 import 'UserInfoProvider.dart';
 
@@ -130,7 +130,7 @@ class SignOutButton extends StatelessWidget {
       onPressed: () {
         authProvider.signOut();
         Navigator.of(context).pushReplacement(
-            MaterialPageRoute(builder: (BuildContext context) => Login()));
+            MaterialPageRoute(builder: (BuildContext context) => HomeOrLogin()));
       },
     );
   }


### PR DESCRIPTION
### Summary <!-- Required -->
Previously, logging out led you to the Login widget, removing the authprovider. Use HomeOrLogin instead so that the authprovider remains in use.
<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->
### Test Plan <!-- Required -->
Login to the app, logout, and log back in again without issues.
<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
