### PR TITLE
Add wakelock to prevent screen from sleeping

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,7 +8,7 @@ void main() {
     child: MyApp(),
   );
 
-  mainCommon();
-
   runApp(configuredApp);
+
+  mainCommon();
 }

--- a/lib/main_common.dart
+++ b/lib/main_common.dart
@@ -1,12 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:wakelock/wakelock.dart';
 import 'AuthProvider.dart';
 import 'Home.dart';
 import 'UserInfoProvider.dart';
 import 'app_config.dart';
 import 'Login.dart';
 
-void mainCommon() {}
+void mainCommon() async {
+  // Prevent screen from sleeping
+  Wakelock.enable();
+}
 
 class MyApp extends StatelessWidget {
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -226,6 +226,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.8"
+  wakelock:
+    dependency: "direct main"
+    description:
+      name: wakelock
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4+2"
 sdks:
   dart: ">=2.9.0-14.0.dev <3.0.0"
   flutter: ">=1.12.1 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   intl: ^0.16.1
   geolocation: ^1.1.2
   provider: ^4.0.5+1
+  wakelock: ^0.1.4+2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Summary <!-- Required -->
Add a wakelock so that the driver's phone does not sleep while they are driving. They will not have to worry about constantly tapping the screen to keep the phone awake.
<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

### Test Plan <!-- Required -->
Install the app onto a device. If using an external device, unplug the device from your computer. With the app open, wait a couple of minutes. If the phone's screen has not gone black, then the wakelock is working.
<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->
There were originally concerns about whether the wakelock would permanently keep the phone on, even outside the app, however, further testing has shown that this is not the case. The wakelock is only in effect while the app is open.
<!--- List any important or subtle points, future considerations, or other items of note. -->
