### PR TITLE
Update homepage, rides in progress, profile for new backend schema

### DIFF
--- a/lib/Home.dart
+++ b/lib/Home.dart
@@ -2,11 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'AuthProvider.dart';
 import 'LocationTracker.dart';
+import 'Ride.dart';
 import 'Rides.dart';
 import 'Upcoming.dart';
 import 'main_common.dart';
 import 'Profile.dart';
 import 'UserInfoProvider.dart';
+import 'RidesInProgress.dart';
 
 class Greeting extends StatelessWidget {
   @override
@@ -75,9 +77,20 @@ class _HomeState extends State<Home> {
   }
 
   Widget getPage(BuildContext context, int index) {
+    Ride r = Ride(
+        id: 'temp',
+        type: 'active',
+        startLocation: 'Upson',
+        endLocation: 'Upson',
+        riderId: '257c3eb0-9142-11ea-b82b-ebf7c42b03f1',
+        driverId: 'fd7348f0-8b10-11ea-8a3b-1365ac031d4f',
+        endTime: DateTime.now(),
+        startTime: DateTime.now()
+    );
     switch (index) {
       case (RIDES):
-        return Rides();
+        return RidesInProgressPage([r, r, r], [r, r, r, r]);
+        //return Rides();
       case (HISTORY):
         return Column(
           children: <Widget>[

--- a/lib/Home.dart
+++ b/lib/Home.dart
@@ -2,13 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'AuthProvider.dart';
 import 'LocationTracker.dart';
-import 'Ride.dart';
 import 'Rides.dart';
-import 'Upcoming.dart';
 import 'main_common.dart';
 import 'Profile.dart';
 import 'UserInfoProvider.dart';
-import 'RidesInProgress.dart';
 
 class Greeting extends StatelessWidget {
   @override
@@ -53,7 +50,6 @@ class _HomeState extends State<Home> {
   static const int PROFILE = 2;
 
   int _selectedIndex = RIDES;
-  List<FutureRide> rides;
 
   @override
   void initState() {
@@ -77,20 +73,9 @@ class _HomeState extends State<Home> {
   }
 
   Widget getPage(BuildContext context, int index) {
-    Ride r = Ride(
-        id: 'temp',
-        type: 'active',
-        startLocation: 'Upson',
-        endLocation: 'Upson',
-        riderId: '257c3eb0-9142-11ea-b82b-ebf7c42b03f1',
-        driverId: 'fd7348f0-8b10-11ea-8a3b-1365ac031d4f',
-        endTime: DateTime.now(),
-        startTime: DateTime.now()
-    );
     switch (index) {
       case (RIDES):
-        return RidesInProgressPage([r, r, r], [r, r, r, r]);
-        //return Rides();
+        return Rides();
       case (HISTORY):
         return Column(
           children: <Widget>[

--- a/lib/Home.dart
+++ b/lib/Home.dart
@@ -105,11 +105,11 @@ class _HomeState extends State<Home> {
           selectedItemColor: Colors.blue,
           items: <BottomNavigationBarItem>[
             BottomNavigationBarItem(
-                icon: Icon(Icons.star), title: Text('Rides')),
+                icon: Icon(Icons.star), label: 'Rides'),
             BottomNavigationBarItem(
-                icon: Icon(Icons.history), title: Text('History')),
+                icon: Icon(Icons.history), label: 'History'),
             BottomNavigationBarItem(
-                icon: Icon(Icons.account_circle), title: Text('Profile'))
+                icon: Icon(Icons.account_circle), label: 'Profile')
           ],
           currentIndex: _selectedIndex,
           onTap: _onItemTapped,

--- a/lib/Profile.dart
+++ b/lib/Profile.dart
@@ -266,7 +266,7 @@ class _EditProfileState extends State<EditProfile> {
               SizedBox(height: 20),
               Form(
                   key: _formKey,
-                  autovalidate: true,
+                  autovalidateMode: AutovalidateMode.onUserInteraction,
                   child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [

--- a/lib/Ride.dart
+++ b/lib/Ride.dart
@@ -12,17 +12,14 @@ class Ride {
   final String endLocation;
   final DateTime startTime;
   final DateTime endTime;
-  final String riderId;
-  // can be null
-  final String driverId;
+  final Rider rider;
 
   Ride({
     this.id,
     this.type,
     this.startLocation,
     this.endLocation,
-    this.riderId,
-    this.driverId,
+    this.rider,
     this.endTime,
     this.startTime});
 
@@ -30,20 +27,15 @@ class Ride {
     return Ride(
       id: json['id'],
       type: json['type'],
-      startLocation: json['startLocation'],
-      endLocation: json['endLocation'],
+      startLocation: json['startLocation']['name'],
+      endLocation: json['endLocation']['name'],
       startTime: DateTime.parse(json['startTime']),
       endTime: DateTime.parse(json['endTime']),
-      riderId: json['riderId'],
-      driverId: json['driverId'],
+      rider: Rider.fromJson(json['rider']),
     );
   }
-
-  Future<String> retrieveRiderName(BuildContext context) async {
-    Rider rider = await Rider.retrieveRider(context, riderId);
-    return rider.firstName;
-  }
 }
+
 T getOrNull<T>(Map<String,dynamic> map, String key, {T parse(dynamic s)}) {
   var x = map.containsKey(key) ? map[key] : null;
   if(x == null) return null;
@@ -95,8 +87,8 @@ class _RideCardState extends State<RideCard> {
   @override
   Widget build(BuildContext context) {
     Widget pickup = Expanded(
-      flex: 4,
-      child: Column(
+        flex: 4,
+        child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
@@ -177,6 +169,7 @@ class _RideCardState extends State<RideCard> {
         child: Padding(
           padding: EdgeInsets.only(top: 24, bottom: 24, left: cardPadding, right: cardPadding),
           child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Row(
                     children: [
@@ -208,46 +201,33 @@ class _RideCardState extends State<RideCard> {
                   ],
                 ),
                 SizedBox(height: 16),
-                FutureBuilder(
-                    future: Rider.retrieveRider(context, widget.ride.riderId),
-                    builder: (context, snapshot) {
-                      if (snapshot.hasError) {
-                        print('error when retrieving a rider for RideCard: ' + snapshot.error.toString());
-                      }
-                      if (!snapshot.hasData) {
-                        return Container();
-                      }
-                      Rider rider = snapshot.data;
-                      return Row(
+                Row(
+                    children: [
+                      CircleAvatar(
+                        radius: 24,
+                        //TODO: replace with rider's image
+                        backgroundImage: AssetImage('assets/images/terry.jpg'),
+                      ),
+                      SizedBox(width: 16),
+                      Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            CircleAvatar(
-                              radius: 24,
-                              //TODO: replace with rider's image
-                              backgroundImage: AssetImage('assets/images/terry.jpg'),
+                            Text(widget.ride.rider.firstName,
+                                style: TextStyle(
+                                  fontSize: 15,
+                                )
                             ),
-                            SizedBox(width: 16),
-                            Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(rider.firstName,
-                                      style: TextStyle(
-                                        fontSize: 15,
-                                      )
-                                  ),
-                                  SizedBox(height: 4),
-                                  /*Text(rider.accessibilityString(),
-                                    style: TextStyle(
-                                        fontSize: 15,
-                                        fontStyle: FontStyle.italic,
-                                        color: Color.fromRGBO(132, 132, 132, 1.0)
-                                    ),
-                                  )*/
-                                ]
+                            SizedBox(height: 4),
+                            Text(widget.ride.rider.accessibilityNeeds.join(', '),
+                                style: TextStyle(
+                                    color: Color(0xFF848484),
+                                    fontStyle: FontStyle.italic,
+                                fontSize: 15)
                             )
                           ]
-                      );
-                    }
-                )
+                      ),
+                    ]
+                ),
               ]
           ),
         )

--- a/lib/Ride.dart
+++ b/lib/Ride.dart
@@ -38,6 +38,11 @@ class Ride {
       driverId: json['driverId'],
     );
   }
+
+  Future<String> retrieveRiderName(BuildContext context) async {
+    Rider rider = await Rider.retrieveRider(context, riderId);
+    return rider.firstName;
+  }
 }
 T getOrNull<T>(Map<String,dynamic> map, String key, {T parse(dynamic s)}) {
   var x = map.containsKey(key) ? map[key] : null;
@@ -230,13 +235,13 @@ class _RideCardState extends State<RideCard> {
                                       )
                                   ),
                                   SizedBox(height: 4),
-                                  Text(rider.accessibilityString(),
+                                  /*Text(rider.accessibilityString(),
                                     style: TextStyle(
                                         fontSize: 15,
                                         fontStyle: FontStyle.italic,
                                         color: Color.fromRGBO(132, 132, 132, 1.0)
                                     ),
-                                  )
+                                  )*/
                                 ]
                             )
                           ]

--- a/lib/RideSummary.dart
+++ b/lib/RideSummary.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'Ride.dart';
+import 'Rider.dart' as rider;
 import 'Upcoming.dart';
 import 'Home.dart';
 import 'package:intl/intl.dart';
@@ -201,14 +202,14 @@ class _RideSummaryState extends State<RideSummary> {
     super.initState();
     // TODO: placeholder
     _currentRide = new Ride(
-        id: "1",
-        type: "past",
-        startLocation: "Teagle Hall",
-        endLocation: "RPCC",
-        startTime: new DateTime(2020,11,14),
-        endTime: new DateTime(2020,11,14),
-        riderId: "Terry Cruz",
-      );
+      id: "1",
+      type: "past",
+      startLocation: "Teagle Hall",
+      endLocation: "RPCC",
+      startTime: new DateTime(2020,11,14),
+      endTime: new DateTime(2020,11,14),
+      rider: rider.Rider('id', 'tc@gmail.com', '111-222-3333', 'Terry', 'Cruz', ['Crutches']),
+    );
   }
 
 // TODO: ignore recent finished ride if it was too long ago
@@ -244,13 +245,13 @@ class _RideSummaryState extends State<RideSummary> {
           Greeting(),
           Expanded(
               child: ListView(shrinkWrap: true, children: <Widget>[
-            _recentRide(),
-            LeftSubheading(heading: 'Upcoming Ride'),
-            Center(child: CurrentRide(_currentRide)),
-            Padding(
-                padding: EdgeInsets.only(top: 36.0, bottom: 24.0),
-                child: DriverStats())
-          ]))
+                _recentRide(),
+                LeftSubheading(heading: 'Upcoming Ride'),
+                Center(child: CurrentRide(_currentRide)),
+                Padding(
+                    padding: EdgeInsets.only(top: 36.0, bottom: 24.0),
+                    child: DriverStats())
+              ]))
         ]);
   }
 

--- a/lib/Rider.dart
+++ b/lib/Rider.dart
@@ -9,12 +9,12 @@ class Rider {
   String phoneNumber;
   String firstName;
   String lastName;
-  //Map<String, dynamic> accessibilityNeeds;
+  List<String> accessibilityNeeds;
 
-  Rider(this.id, this.email, this.phoneNumber, this.firstName, this.lastName);
+  Rider(this.id, this.email, this.phoneNumber, this.firstName, this.lastName, this.accessibilityNeeds);
 
   factory Rider.fromJson(Map<String, dynamic> json) {
-    return Rider(json['id'], json['email'], json['phoneNumber'], json['firstName'], json['lastName']);
+    return Rider(json['id'], json['email'], json['phoneNumber'], json['firstName'], json['lastName'], List.from(json['accessibility']));
   }
 
   /*String accessibilityString() {

--- a/lib/Rider.dart
+++ b/lib/Rider.dart
@@ -9,15 +9,15 @@ class Rider {
   String phoneNumber;
   String firstName;
   String lastName;
-  Map<String, dynamic> accessibilityNeeds;
+  //Map<String, dynamic> accessibilityNeeds;
 
-  Rider(this.id, this.email, this.phoneNumber, this.firstName, this.lastName, this.accessibilityNeeds);
+  Rider(this.id, this.email, this.phoneNumber, this.firstName, this.lastName);
 
   factory Rider.fromJson(Map<String, dynamic> json) {
-    return Rider(json['id'], json['email'], json['phoneNumber'], json['firstName'], json['lastName'], Map<String, dynamic>.from(json['accessibilityNeeds']));
+    return Rider(json['id'], json['email'], json['phoneNumber'], json['firstName'], json['lastName']);
   }
 
-  String accessibilityString() {
+  /*String accessibilityString() {
     Map<String, String> needs = {
       'needsWheelchair': 'Wheelchair',
       'hasCrutches': 'Crutches',
@@ -38,7 +38,7 @@ class Rider {
       str = str.substring(0, str.length - 2);
     }
     return str;
-  }
+  }*/
 
   static Future<Rider> retrieveRider(BuildContext context, String id) async {
     final response = await http.get(AppConfig.of(context).baseUrl + '/riders/$id');

--- a/lib/Rider.dart
+++ b/lib/Rider.dart
@@ -17,29 +17,6 @@ class Rider {
     return Rider(json['id'], json['email'], json['phoneNumber'], json['firstName'], json['lastName'], List.from(json['accessibility']));
   }
 
-  /*String accessibilityString() {
-    Map<String, String> needs = {
-      'needsWheelchair': 'Wheelchair',
-      'hasCrutches': 'Crutches',
-      'needsAssistant': 'Assistant'
-    };
-    String str = '';
-    needs.forEach((need, name) {
-      if (accessibilityNeeds[need]) {
-        str += name;
-        str += ', ';
-      }
-    });
-    if (str.isEmpty) {
-      str = 'None';
-    }
-    else {
-      // remove trailing comma
-      str = str.substring(0, str.length - 2);
-    }
-    return str;
-  }*/
-
   static Future<Rider> retrieveRider(BuildContext context, String id) async {
     final response = await http.get(AppConfig.of(context).baseUrl + '/riders/$id');
     if (response.statusCode == 200) {

--- a/lib/Rides.dart
+++ b/lib/Rides.dart
@@ -21,7 +21,7 @@ class _RidesState extends State<Rides> {
   Future<List<Ride>> _fetchRides(String id) async {
     final dateFormat = DateFormat("yyyy-MM-dd");
     DateTime now = DateTime.now();
-    final response = await http.get(AppConfig.of(context).baseUrl + '/rides/active?date=${dateFormat.format(now)}&driverId=${Provider.of<AuthProvider>(context).id}');
+    final response = await http.get(AppConfig.of(context).baseUrl + '/rides/unscheduled?date=${dateFormat.format(now)}&driverId=${Provider.of<AuthProvider>(context).id}');
     if (response.statusCode == 200) {
       String responseBody = response.body;
       List<Ride> rides = _ridesFromJson(responseBody);

--- a/lib/Rides.dart
+++ b/lib/Rides.dart
@@ -21,7 +21,7 @@ class _RidesState extends State<Rides> {
   Future<List<Ride>> _fetchRides(String id) async {
     final dateFormat = DateFormat("yyyy-MM-dd");
     DateTime now = DateTime.now();
-    final response = await http.get(AppConfig.of(context).baseUrl + '/rides/unscheduled?date=${dateFormat.format(now)}&driverId=${Provider.of<AuthProvider>(context).id}');
+    final response = await http.get(AppConfig.of(context).baseUrl + '/rides?date=${dateFormat.format(now)}&driver=${Provider.of<AuthProvider>(context).id}');
     if (response.statusCode == 200) {
       String responseBody = response.body;
       List<Ride> rides = _ridesFromJson(responseBody);

--- a/lib/RidesInProgress.dart
+++ b/lib/RidesInProgress.dart
@@ -2,23 +2,41 @@ import 'package:carriage/Ride.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+BoxDecoration dropShadow = BoxDecoration(
+    color: Colors.white,
+    borderRadius: BorderRadius.all(Radius.circular(8)),
+    boxShadow: [
+      BoxShadow(
+        color: Colors.black.withOpacity(0.07),
+        blurRadius: 20,
+        offset: Offset(0, 7), // changes position of shadow
+      ),
+    ]
+);
+
 class Locations extends StatelessWidget {
   Locations(this.startLocation, this.endLocation);
   final String startLocation;
   final String endLocation;
   @override
   Widget build(BuildContext context) {
-    TextStyle fromToStyle = TextStyle(fontSize: 15, color: Colors.grey[400]);
+    TextStyle fromToStyle = TextStyle(fontSize: 15, color: Color(0x7F1A051D));
+    TextStyle locationStyle = TextStyle(fontSize: 15, color: Color(0xFF1A051D));
     return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [Text('From', style: fromToStyle), SizedBox(height: 2), Text(startLocation)]
+        Expanded(
+          child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [Text('From', style: fromToStyle), SizedBox(height: 2), Text(startLocation, style: locationStyle)]
+          ),
         ),
         SizedBox(width: 24),
-        Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [Text('To', style: fromToStyle), SizedBox(height: 2), Text(endLocation)]
+        Expanded(
+            child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [Text('To', style: fromToStyle), SizedBox(height: 2), Text(endLocation, style: locationStyle)]
+            )
         )
       ],
     );
@@ -33,11 +51,11 @@ class PickupTime extends StatelessWidget {
     return RichText(
       text: TextSpan(
           text: 'Pick up time: ',
-          style: TextStyle(fontSize: 13, color: Colors.grey[850]),
+          style: TextStyle(fontSize: 13, color: Color(0xFF3F3356)),
           children: [
             TextSpan(
                 text: DateFormat('jm').format(time),
-                style: TextStyle(fontSize: 13, color: Colors.grey[850], fontWeight: FontWeight.bold)
+                style: TextStyle(fontSize: 13, color: Color(0xFF3F3356), fontWeight: FontWeight.bold)
             )
           ]
       ),
@@ -51,10 +69,11 @@ class BigRideInProgressCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Center(
       child: Container(
-        width: MediaQuery.of(context).size.width * 0.75,
-        child: Card(
+        width: 237,
+        child: DecoratedBox(
+            decoration: dropShadow,
             child: Padding(
-              padding: const EdgeInsets.all(16),
+              padding: const EdgeInsets.all(24),
               child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
@@ -70,12 +89,13 @@ class BigRideInProgressCard extends StatelessWidget {
                     Locations(ride.startLocation, ride.endLocation),
                     SizedBox(height: 16),
                     PickupTime(ride.startTime),
-                    SizedBox(height: 8),
+                    SizedBox(height: 16),
                     SizedBox(
                       width: double.infinity,
                       child: FlatButton(
+                        padding: EdgeInsets.only(top: 10, bottom: 10),
                         color: Colors.black,
-                        child: Text('Drop off', style: TextStyle(color: Colors.white)),
+                        child: Text('Drop off', style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold)),
                         onPressed: () {
                           //TODO: add action when press drop off
                         },
@@ -115,13 +135,13 @@ class _SmallRideInProgressCardState extends State<SmallRideInProgressCard> {
           }
         });
       },
-      child: Card(
-          color: selected ? Colors.grey[300] : Colors.white,
-          child: Padding(
+      child: DecoratedBox(
+          decoration: dropShadow.copyWith(color: selected ? Color(0xFFBDBDBD) : Colors.white),
+          child: Container(
             padding: const EdgeInsets.all(16),
             child: Column(
-              mainAxisSize: MainAxisSize.max,
-              crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.max,
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   selected ?
                   Icon(
@@ -133,7 +153,7 @@ class _SmallRideInProgressCardState extends State<SmallRideInProgressCard> {
                     height: 20,
                     decoration: BoxDecoration(
                         shape: BoxShape.circle,
-                        color: Colors.grey[300]),
+                        color: Color(0x7FC4C4C4)),
                   ) ,
                   Center(
                     child: CircleAvatar(
@@ -142,25 +162,35 @@ class _SmallRideInProgressCardState extends State<SmallRideInProgressCard> {
                     ),
                   ),
                   SizedBox(height: 8),
-                  Center(child: Text(widget.ride.riderId[0], style: Theme.of(context).textTheme.subtitle1)),
+                  Center(
+                      child: FutureBuilder<String>(
+                          future: widget.ride.retrieveRiderName(context),
+                          builder: (context, snapshot) {
+                            if (!snapshot.hasData) {
+                              return SizedBox(width: 20, height: 20, child: CircularProgressIndicator());
+                            }
+                            return Text(snapshot.data, style: Theme.of(context).textTheme.subtitle1);
+                          }
+                      )
+                  ),
                   SizedBox(height: 8),
                   RichText(
                     text: TextSpan(
                         text: 'To ',
-                        style: TextStyle(fontSize: 15, color: Colors.grey[400]),
-                      children: [
-                        TextSpan(
-                          text: widget.ride.endLocation,
-                          style: TextStyle(fontSize: 15, color: Colors.black)
-                        )
-                      ]
+                        style: TextStyle(fontSize: 15, color: Color(0x7F3F3356)),
+                        children: [
+                          TextSpan(
+                              text: widget.ride.endLocation,
+                              style: TextStyle(fontSize: 15, color: Colors.black)
+                          )
+                        ]
                     ),
                   ),
                   SizedBox(height: 8),
                   RichText(
                     text: TextSpan(
                         text: 'Drop off by ',
-                        style: TextStyle(fontSize: 15, color: Colors.grey[400]),
+                        style: TextStyle(fontSize: 15, color: Color(0x7F3F3356)),
                         children: [
                           TextSpan(
                               text: DateFormat('jm').format(widget.ride.endTime),
@@ -182,8 +212,10 @@ class OtherRideCard extends StatelessWidget {
   final Ride ride;
   Widget build(BuildContext context) {
     return Container(
+      margin: EdgeInsets.only(left: 4, right: 4, top: 16, bottom: 32),
       constraints: BoxConstraints(minWidth: 200),
-      child: Card(
+      child: DecoratedBox(
+          decoration: dropShadow,
           child: Padding(
             padding: const EdgeInsets.all(16),
             child: Column(
@@ -196,7 +228,15 @@ class OtherRideCard extends StatelessWidget {
                         backgroundImage: AssetImage('assets/images/terry.jpg'),
                       ),
                       SizedBox(width: 16),
-                      Text(ride.riderId[0], style: Theme.of(context).textTheme.subtitle1)
+                      FutureBuilder<String>(
+                          future: ride.retrieveRiderName(context),
+                          builder: (context, snapshot) {
+                            if (!snapshot.hasData) {
+                              return SizedBox(width: 20, height: 20, child: CircularProgressIndicator());
+                            }
+                            return Text(snapshot.data, style: Theme.of(context).textTheme.subtitle1);
+                          }
+                      )
                     ],
                   ),
                   SizedBox(height: 16),
@@ -236,72 +276,92 @@ class _RidesInProgressPageState extends State<RidesInProgressPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+        backgroundColor: Colors.white,
         body: SafeArea(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: SingleChildScrollView(
-                child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      GestureDetector(
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Icon(Icons.keyboard_arrow_left),
-                              Text('Home')
-                            ]
-                        ),
-                        onTap: () {
-                          //TODO: add navigation when home button pressed
-                        },
-                      ),
-                      SizedBox(height: 16),
-                      Container(
-                        width: 20,
-                        height: 20,
-                        child: Center(child: Text(widget.currentRides.length.toString(), style: TextStyle(color: Colors.white))),
-                        decoration: BoxDecoration(
-                            shape: BoxShape.circle,
-                            color: Colors.black),
-                      ),
-                      Text('Ride(s) In Progress', style: Theme.of(context).textTheme.headline5),
-                      widget.currentRides.length == 1 ?
-                      BigRideInProgressCard(widget.currentRides[0]) :
-                      GridView.count(
-                        physics: NeverScrollableScrollPhysics(),
-                        crossAxisCount: 2,
-                        //TODO: figure out how to not hardcode aspect ratio
-                        childAspectRatio: 0.8,
-                        shrinkWrap: true,
-                        children: widget.currentRides.map((ride) => SmallRideInProgressCard(ride, selectRide)).toList(),
-                      ),
-                      SizedBox(height: 24),
-                      Text('Do you also want to pick up...', style: Theme.of(context).textTheme.subtitle1),
-                      SizedBox(height: 16),
-                      SingleChildScrollView(
-                        scrollDirection: Axis.horizontal,
-                        child: Row(
-                          children: widget.otherRides.map((ride) => OtherRideCard(ride)).toList(),
-                        ),
-                      ),
-                      selectedRides.isNotEmpty ? SizedBox(
-                        width: double.infinity,
-                        child: FlatButton(
-                          padding: EdgeInsets.all(16),
-                          //TODO: change rider ID to rider name
-                          color: Colors.black,
-                          child: Text('Drop off ' + (selectedRides.length == 1 ?
-                          selectedRides[0].riderId[0] :
-                          'Multiple Passengers'),
-                          style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold,)),
-                          onPressed: () {
-                            //TODO: add action when press drop off
+            child: SingleChildScrollView(
+              child: Column(
+                children: [
+                  Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        SizedBox(height: 16),
+                        GestureDetector(
+                          child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Icon(Icons.keyboard_arrow_left, size: 30),
+                                Text('Home', style: TextStyle(fontSize: 17))
+                              ]
+                          ),
+                          onTap: () {
+                            //TODO: add navigation when home button pressed
                           },
                         ),
-                      ) : Container()
-                    ]
-                ),
+                        SizedBox(height: 24),
+                        Padding(
+                          padding: const EdgeInsets.only(left: 16),
+                          child: Container(
+                            width: 24,
+                            height: 24,
+                            child: Center(child: Text(widget.currentRides.length.toString(), style: TextStyle(color: Colors.white))),
+                            decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: Colors.black),
+                          ),
+                        ),
+                        SizedBox(height: 4),
+                        Padding(
+                          padding: const EdgeInsets.only(left: 16),
+                          child: Text('Ride(s) In Progress', style: Theme.of(context).textTheme.headline5),
+                        ),
+                        widget.currentRides.length == 1 ?
+                        BigRideInProgressCard(widget.currentRides[0]) :
+                        GridView.count(
+                          padding: EdgeInsets.only(top: 24, bottom: 32, left: 16, right: 16),
+                          mainAxisSpacing: 16,
+                          crossAxisSpacing: 16,
+                          physics: NeverScrollableScrollPhysics(),
+                          crossAxisCount: 2,
+                          childAspectRatio: 0.8,
+                          shrinkWrap: true,
+                          children: widget.currentRides.map((ride) => SmallRideInProgressCard(ride, selectRide)).toList(),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.only(left: 16),
+                          child: Text('Do you also want to pick up...', style: Theme.of(context).textTheme.subtitle1),
+                        ),
+                        SingleChildScrollView(
+                          scrollDirection: Axis.horizontal,
+                          child: Row(
+                              children: [SizedBox(width: 16), SizedBox(width: 16)]..insertAll(1, widget.otherRides.map((ride) => OtherRideCard(ride)).toList())
+                          ),
+                        ),
+                        selectedRides.isNotEmpty ? SizedBox(
+                          width: double.infinity,
+                          child: FlatButton(
+                            padding: EdgeInsets.all(16),
+                            //TODO: change rider ID to rider name
+                            color: Colors.black,
+                            child: FutureBuilder<String>(
+                                future: selectedRides[0].retrieveRiderName(context),
+                                builder: (context, snapshot) {
+                                  if (!snapshot.hasData) {
+                                    return SizedBox(width: 20, height: 20, child: CircularProgressIndicator());
+                                  }
+                                  return Text('Drop off ' + (selectedRides.length == 1 ? snapshot.data : 'Multiple Passengers'),
+                                      style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold)
+                                  );
+                                }
+                            ),
+                            onPressed: () {
+                              //TODO: add action when press drop off
+                            },
+                          ),
+                        ) : Container(),
+                      ]
+                  ),
+                ],
               ),
             )
         )

--- a/lib/RidesInProgress.dart
+++ b/lib/RidesInProgress.dart
@@ -163,15 +163,7 @@ class _SmallRideInProgressCardState extends State<SmallRideInProgressCard> {
                   ),
                   SizedBox(height: 8),
                   Center(
-                      child: FutureBuilder<String>(
-                          future: widget.ride.retrieveRiderName(context),
-                          builder: (context, snapshot) {
-                            if (!snapshot.hasData) {
-                              return SizedBox(width: 20, height: 20, child: CircularProgressIndicator());
-                            }
-                            return Text(snapshot.data, style: Theme.of(context).textTheme.subtitle1);
-                          }
-                      )
+                      child: Text(widget.ride.rider.firstName, style: Theme.of(context).textTheme.subtitle1)
                   ),
                   SizedBox(height: 8),
                   RichText(
@@ -228,15 +220,7 @@ class OtherRideCard extends StatelessWidget {
                         backgroundImage: AssetImage('assets/images/terry.jpg'),
                       ),
                       SizedBox(width: 16),
-                      FutureBuilder<String>(
-                          future: ride.retrieveRiderName(context),
-                          builder: (context, snapshot) {
-                            if (!snapshot.hasData) {
-                              return SizedBox(width: 20, height: 20, child: CircularProgressIndicator());
-                            }
-                            return Text(snapshot.data, style: Theme.of(context).textTheme.subtitle1);
-                          }
-                      )
+                      Text(ride.rider.firstName, style: Theme.of(context).textTheme.subtitle1)
                     ],
                   ),
                   SizedBox(height: 16),
@@ -341,18 +325,9 @@ class _RidesInProgressPageState extends State<RidesInProgressPage> {
                           width: double.infinity,
                           child: FlatButton(
                             padding: EdgeInsets.all(16),
-                            //TODO: change rider ID to rider name
                             color: Colors.black,
-                            child: FutureBuilder<String>(
-                                future: selectedRides[0].retrieveRiderName(context),
-                                builder: (context, snapshot) {
-                                  if (!snapshot.hasData) {
-                                    return SizedBox(width: 20, height: 20, child: CircularProgressIndicator());
-                                  }
-                                  return Text('Drop off ' + (selectedRides.length == 1 ? snapshot.data : 'Multiple Passengers'),
-                                      style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold)
-                                  );
-                                }
+                            child: Text('Drop off ' + (selectedRides.length == 1 ? selectedRides[0].rider.firstName : 'Multiple Passengers'),
+                                style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold)
                             ),
                             onPressed: () {
                               //TODO: add action when press drop off

--- a/lib/UserInfoProvider.dart
+++ b/lib/UserInfoProvider.dart
@@ -94,7 +94,7 @@ class UserInfo {
         startTime: json['startTime'],
         endTime: json['endTime'],
         breaks: Breaks.fromJson(json['breaks']),
-        vehicle: json['vehicle'],
+        vehicle: json['vehicle']['name'],
         phoneNumber: json['phoneNumber'],
         email: json['email'],
         photoUrl: photoUrl);

--- a/lib/main_common.dart
+++ b/lib/main_common.dart
@@ -35,16 +35,17 @@ class MyApp extends StatelessWidget {
         child: MaterialApp(
             title: 'Carriage',
             theme: ThemeData(
+                scaffoldBackgroundColor: Colors.white,
                 primarySwatch: Colors.red,
                 fontFamily: 'SFPro',
                 accentColor: Color.fromRGBO(60, 60, 67, 0.6),
                 textTheme: TextTheme(
                     headline5:
-                        TextStyle(fontSize: 36, fontWeight: FontWeight.bold),
+                    TextStyle(fontSize: 36, fontWeight: FontWeight.bold),
                     subtitle1:
-                        TextStyle(fontSize: 17.0, fontWeight: FontWeight.bold),
+                    TextStyle(fontSize: 17.0, fontWeight: FontWeight.bold),
                     headline4:
-                        TextStyle(fontSize: 12.0, fontWeight: FontWeight.bold),
+                    TextStyle(fontSize: 12.0, fontWeight: FontWeight.bold),
                     headline3: TextStyle(
                         fontSize: 12.0, fontWeight: FontWeight.normal),
                     headline2: TextStyle(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0-nullsafety.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.1"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0-nullsafety.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0-nullsafety.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.13"
+    version: "1.15.0-nullsafety.3"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -56,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -115,14 +115,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.8"
+    version: "0.12.10-nullsafety.1"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0-nullsafety.3"
   nested:
     dependency: transitive
     description:
@@ -136,7 +136,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety.1"
   pedantic:
     dependency: transitive
     description:
@@ -169,21 +169,21 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.5"
+    version: "1.10.0-nullsafety.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.1"
   streams_channel:
     dependency: transitive
     description:
@@ -197,35 +197,35 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0-nullsafety.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.17"
+    version: "0.2.19-nullsafety.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0-nullsafety.3"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0-nullsafety.3"
   wakelock:
     dependency: "direct main"
     description:
@@ -234,5 +234,5 @@ packages:
     source: hosted
     version: "0.1.4+2"
 sdks:
-  dart: ">=2.9.0-14.0.dev <3.0.0"
+  dart: ">=2.10.0-110 <2.11.0"
   flutter: ">=1.12.1 <2.0.0"


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is the first step towards updating the homepage, rides in progress page, and profile pages to match the new rides, locations, accessibility, and vehicle backend schema

- [x] Updated colors and spacing on rides in progress page to fully match design
- [x] Fixed ride cards on homepage to display accessibility needs, name, and locations again
- [x] Fixed profile to display vehicle name again
- [x] Fixed rides in progress page to display names again
- [ ] Connect rides in progress page to backend

### Test Plan <!-- Required -->
Tested on my device locally

Homepage:
![image](https://user-images.githubusercontent.com/60579411/95926459-5d7c3080-0d8a-11eb-93b1-2c315d9c15ee.png)

Rides in progress:
![image](https://user-images.githubusercontent.com/60579411/95926464-62d97b00-0d8a-11eb-92e3-e8ae5c895da1.png)

Profile:
![image](https://user-images.githubusercontent.com/60579411/95926499-771d7800-0d8a-11eb-8548-c57b020b8b41.png)

### Notes <!-- Optional -->
The rides in progress page still uses a temporary ride, will connect to backend when we have backend set up to store the state of rides
