### PR TITLE
Ride status updates in backend

### DIFF
--- a/lib/Home.dart
+++ b/lib/Home.dart
@@ -107,11 +107,11 @@ class _HomeState extends State<Home> {
           selectedItemColor: Colors.blue,
           items: <BottomNavigationBarItem>[
             BottomNavigationBarItem(
-                icon: Icon(Icons.star), title: Text('Rides')),
+              icon: Icon(Icons.star), label: 'Rides'),
             BottomNavigationBarItem(
-                icon: Icon(Icons.history), title: Text('History')),
+                icon: Icon(Icons.history), label: 'History'),
             BottomNavigationBarItem(
-                icon: Icon(Icons.account_circle), title: Text('Profile'))
+                icon: Icon(Icons.account_circle), label: 'Profile')
           ],
           currentIndex: _selectedIndex,
           onTap: _onItemTapped,
@@ -129,8 +129,8 @@ class SignOutButton extends StatelessWidget {
       child: Text('Sign out', textAlign: TextAlign.start),
       onPressed: () {
         authProvider.signOut();
-        Navigator.of(context).pushReplacement(
-            MaterialPageRoute(builder: (BuildContext context) => HomeOrLogin()));
+        Navigator.of(context).pushReplacement(MaterialPageRoute(
+            builder: (BuildContext context) => HomeOrLogin()));
       },
     );
   }

--- a/lib/Profile.dart
+++ b/lib/Profile.dart
@@ -124,7 +124,8 @@ class _ProfileState extends State<Profile> {
                 Icons.mail_outline,
                 userInfoProvider.info.email,
               ),
-              InfoRow("phone number", Icons.phone, userInfoProvider.info.phoneNumber)
+              InfoRow("phone number", Icons.phone,
+                  userInfoProvider.info.phoneNumber)
             ],
           ),
           SizedBox(height: 6),
@@ -139,7 +140,8 @@ class _ProfileState extends State<Profile> {
                   (userInfoProvider.info.breaks == null)
                       ? 'None'
                       : userInfoProvider.info.breaks.toString()),
-              InfoRow("vehicle", Icons.directions_car, userInfoProvider.info.vehicle),
+              InfoRow("vehicle", Icons.directions_car,
+                  userInfoProvider.info.vehicle),
             ],
           )
         ],
@@ -216,7 +218,7 @@ class _InfoGroupState extends State<InfoGroup> {
               children: <Widget>[
                 Text(widget.title,
                     style:
-                    TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+                        TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
                 ListView.separated(
                     padding: EdgeInsets.all(0),
                     shrinkWrap: true,
@@ -260,13 +262,13 @@ class _EditProfileState extends State<EditProfile> {
               top: 18.0 + MediaQuery.of(context).padding.top,
             ),
             child:
-            Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+                Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
               Text('Edit Profile',
                   style: Theme.of(context).textTheme.headline5),
               SizedBox(height: 20),
               Form(
                   key: _formKey,
-                  autovalidate: true,
+                  autovalidateMode: AutovalidateMode.always,
                   child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [

--- a/lib/Ride.dart
+++ b/lib/Ride.dart
@@ -1,13 +1,30 @@
+import 'dart:convert';
 import 'dart:core';
 import 'package:carriage/MeasureSize.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:http/http.dart' as http;
 import 'package:intl/intl.dart';
 import 'Rider.dart';
+import 'app_config.dart';
+
+enum RideStatus { NOT_STARTED, ON_THE_WAY, ARRIVED, PICKED_UP, COMPLETED }
+
+String toString(RideStatus status) {
+  const mapping = <RideStatus, String>{
+    RideStatus.NOT_STARTED: "not_started",
+    RideStatus.ON_THE_WAY: "on_the_way",
+    RideStatus.ARRIVED: "arrived",
+    RideStatus.PICKED_UP: "picked_up",
+    RideStatus.COMPLETED: "completed",
+  };
+  return mapping[status];
+}
 
 class Ride {
   final String id;
   final String type;
+  final RideStatus status;
   final String startLocation;
   final String endLocation;
   final DateTime startTime;
@@ -16,20 +33,22 @@ class Ride {
   // can be null
   final String driverId;
 
-  Ride({
-    this.id,
-    this.type,
-    this.startLocation,
-    this.endLocation,
-    this.riderId,
-    this.driverId,
-    this.endTime,
-    this.startTime});
+  Ride(
+      {this.id,
+      this.type,
+      this.status,
+      this.startLocation,
+      this.endLocation,
+      this.riderId,
+      this.driverId,
+      this.endTime,
+      this.startTime});
 
-  factory Ride.fromJson(Map<String,dynamic> json) {
+  factory Ride.fromJson(Map<String, dynamic> json) {
     return Ride(
       id: json['id'],
       type: json['type'],
+      status: json['status'],
       startLocation: json['startLocation'],
       endLocation: json['endLocation'],
       startTime: DateTime.parse(json['startTime']),
@@ -39,10 +58,19 @@ class Ride {
     );
   }
 }
-T getOrNull<T>(Map<String,dynamic> map, String key, {T parse(dynamic s)}) {
+
+Future<http.Response> updateRideStatus(
+    BuildContext context, String id, RideStatus status) async {
+  final body = jsonEncode(<String, String>{"status": toString(status)});
+  return http.put(AppConfig.of(context).baseUrl + '/rides/$id',
+      body: body,
+      headers: <String, String>{"Content-Type": "application/json"});
+}
+
+T getOrNull<T>(Map<String, dynamic> map, String key, {T parse(dynamic s)}) {
   var x = map.containsKey(key) ? map[key] : null;
-  if(x == null) return null;
-  if(parse == null) return x;
+  if (x == null) return null;
+  if (parse == null) return x;
   return parse(x);
 }
 
@@ -55,11 +83,11 @@ class ArrowPainter extends CustomPainter {
     Paint paint = Paint()
       ..strokeWidth = 2
       ..color = Colors.black;
-    canvas.drawLine(Offset(0, 0), Offset(length-5, 0), paint);
+    canvas.drawLine(Offset(0, 0), Offset(length - 5, 0), paint);
     paint.style = PaintingStyle.fill;
     Path trianglePath = Path();
-    trianglePath.moveTo(length-5, 5);
-    trianglePath.lineTo(length-5, -5);
+    trianglePath.moveTo(length - 5, 5);
+    trianglePath.lineTo(length - 5, -5);
     trianglePath.lineTo(length, 0);
     trianglePath.close();
     canvas.drawPath(trianglePath, paint);
@@ -90,44 +118,35 @@ class _RideCardState extends State<RideCard> {
   @override
   Widget build(BuildContext context) {
     Widget pickup = Expanded(
-      flex: 4,
-      child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                  'From',
-                  style: TextStyle(fontSize: 11, color: Color.fromRGBO(132, 132, 132, 0.5))
+        flex: 4,
+        child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+          Text('From',
+              style: TextStyle(
+                  fontSize: 11, color: Color.fromRGBO(132, 132, 132, 0.5))),
+          Container(
+            child: MeasureSize(
+              child: Text(
+                widget.ride.startLocation,
+                style: TextStyle(fontSize: 17),
+                textWidthBasis: TextWidthBasis.longestLine,
               ),
-              Container(
-                child: MeasureSize(
-                  child: Text(
-                    widget.ride.startLocation,
-                    style: TextStyle(fontSize: 17),
-                    textWidthBasis: TextWidthBasis.longestLine,
-                  ),
-                  onChange: (size) {
-                    pickupTextSize = size;
-                  },
-                ),
-              )
-            ]
-        )
-    );
+              onChange: (size) {
+                pickupTextSize = size;
+              },
+            ),
+          )
+        ]));
 
     Widget dropOff = Expanded(
       flex: 4,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-              'To',
-              style: TextStyle(fontSize: 11, color: Color.fromRGBO(132, 132, 132, 0.5))
-          ),
-          Text(
-              widget.ride.endLocation,
-              key: dropoffKey,
-              style: TextStyle(fontSize: 17)
-          )
+          Text('To',
+              style: TextStyle(
+                  fontSize: 11, color: Color.fromRGBO(132, 132, 132, 0.5))),
+          Text(widget.ride.endLocation,
+              key: dropoffKey, style: TextStyle(fontSize: 17))
         ],
       ),
     );
@@ -153,100 +172,94 @@ class _RideCardState extends State<RideCard> {
     double calculateArrowStart() {
       return pickupTextSize.width + arrowPadding;
     }
+
     double calculateArrowLength() {
-      double idealLength = getDropoffX() - cardPadding - widget.pagePadding - pickupTextSize.width - (arrowPadding * 2);
+      double idealLength = getDropoffX() -
+          cardPadding -
+          widget.pagePadding -
+          pickupTextSize.width -
+          (arrowPadding * 2);
       return idealLength;
     }
 
-    Widget arrow = pickupTextSize != null && spacerSize != null ?
-    Positioned(
-        left: calculateArrowStart(),
-        top: getDropoffY(),
-        child: CustomPaint(
-            painter: ArrowPainter(calculateArrowLength())
-        )
-    ) : Container();
+    Widget arrow = pickupTextSize != null && spacerSize != null
+        ? Positioned(
+            left: calculateArrowStart(),
+            top: getDropoffY(),
+            child: CustomPaint(painter: ArrowPainter(calculateArrowLength())))
+        : Container();
 
     Widget card = Card(
         elevation: 3.0,
         child: Padding(
-          padding: EdgeInsets.only(top: 24, bottom: 24, left: cardPadding, right: cardPadding),
-          child: Column(
+          padding: EdgeInsets.only(
+              top: 24, bottom: 24, left: cardPadding, right: cardPadding),
+          child: Column(children: [
+            Row(children: [
+              Text('Pickup',
+                  style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+              SizedBox(width: 5),
+              Text(DateFormat.jm().format(widget.ride.startTime),
+                  style: TextStyle(fontSize: 20))
+            ]),
+            SizedBox(height: 9),
+            Stack(
+              key: stackKey,
               children: [
-                Row(
-                    children: [
-                      Text('Pickup', style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
-                      SizedBox(width: 5),
-                      Text(DateFormat.jm().format(widget.ride.startTime), style: TextStyle(fontSize: 20))
-                    ]
-                ),
-                SizedBox(height: 9),
-                Stack(
-                  key: stackKey,
-                  children: [
-                    arrow,
-                    Row(
+                arrow,
+                Row(crossAxisAlignment: CrossAxisAlignment.start, children: [
+                  pickup,
+                  MeasureSize(
+                    child: Expanded(flex: 2, child: SizedBox()),
+                    onChange: (size) {
+                      setState(() {
+                        spacerSize = size;
+                      });
+                    },
+                  ),
+                  dropOff
+                ]),
+              ],
+            ),
+            SizedBox(height: 16),
+            FutureBuilder(
+                future: Rider.retrieveRider(context, widget.ride.riderId),
+                builder: (context, snapshot) {
+                  if (snapshot.hasError) {
+                    print('error when retrieving a rider for RideCard: ' +
+                        snapshot.error.toString());
+                  }
+                  if (!snapshot.hasData) {
+                    return Container();
+                  }
+                  Rider rider = snapshot.data;
+                  return Row(children: [
+                    CircleAvatar(
+                      radius: 24,
+                      //TODO: replace with rider's image
+                      backgroundImage: AssetImage('assets/images/terry.jpg'),
+                    ),
+                    SizedBox(width: 16),
+                    Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          pickup,
-                          MeasureSize(
-                            child: Expanded(flex: 2, child: SizedBox()),
-                            onChange: (size) {
-                              setState(() {
-                                spacerSize = size;
-                              });
-                            },
-                          ),
-                          dropOff
-                        ]
-                    ),
-                  ],
-                ),
-                SizedBox(height: 16),
-                FutureBuilder(
-                    future: Rider.retrieveRider(context, widget.ride.riderId),
-                    builder: (context, snapshot) {
-                      if (snapshot.hasError) {
-                        print('error when retrieving a rider for RideCard: ' + snapshot.error.toString());
-                      }
-                      if (!snapshot.hasData) {
-                        return Container();
-                      }
-                      Rider rider = snapshot.data;
-                      return Row(
-                          children: [
-                            CircleAvatar(
-                              radius: 24,
-                              //TODO: replace with rider's image
-                              backgroundImage: AssetImage('assets/images/terry.jpg'),
-                            ),
-                            SizedBox(width: 16),
-                            Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(rider.firstName,
-                                      style: TextStyle(
-                                        fontSize: 15,
-                                      )
-                                  ),
-                                  SizedBox(height: 4),
-                                  Text(rider.accessibilityString(),
-                                    style: TextStyle(
-                                        fontSize: 15,
-                                        fontStyle: FontStyle.italic,
-                                        color: Color.fromRGBO(132, 132, 132, 1.0)
-                                    ),
-                                  )
-                                ]
-                            )
-                          ]
-                      );
-                    }
-                )
-              ]
-          ),
-        )
-    );
+                          Text(rider.firstName,
+                              style: TextStyle(
+                                fontSize: 15,
+                              )),
+                          SizedBox(height: 4),
+                          Text(
+                            rider.accessibilityString(),
+                            style: TextStyle(
+                                fontSize: 15,
+                                fontStyle: FontStyle.italic,
+                                color: Color.fromRGBO(132, 132, 132, 1.0)),
+                          )
+                        ])
+                  ]);
+                })
+          ]),
+        ));
 
     return card;
   }

--- a/lib/pages/BeginRidePage.dart
+++ b/lib/pages/BeginRidePage.dart
@@ -1,10 +1,11 @@
 import 'package:carriage/MeasureSize.dart';
+import 'package:carriage/Ride.dart';
+import 'package:carriage/pages/OnTheWayPage.dart';
 import 'package:carriage/widgets/AppBars.dart';
 import 'package:carriage/widgets/Buttons.dart';
-import 'package:carriage/widgets/Dialogs.dart';
 import 'package:carriage/widgets/RideDestPickupCard.dart';
-import 'package:carriage/widgets/RideInfoCard.dart';
 import 'package:flutter/material.dart';
+import 'package:loading_overlay/loading_overlay.dart';
 
 class _StopCircle extends StatelessWidget {
   final bool _dropoff;
@@ -111,14 +112,20 @@ class _TempPageData {
   final DateTime time;
   final String stop;
   final String address;
+  final String rideId;
 
   final List<_StopData> stops;
 
   _TempPageData(this.firstName, this.photo, this.time, this.stop, this.address,
-      this.stops);
+      this.stops, this.rideId);
 }
 
-class BeginRidePage extends StatelessWidget {
+class BeginRidePage extends StatefulWidget {
+  @override
+  _BeginRidePageState createState() => _BeginRidePageState();
+}
+
+class _BeginRidePageState extends State<BeginRidePage> {
   final _TempPageData data = _TempPageData(
       "Alex",
       NetworkImage(
@@ -129,7 +136,10 @@ class BeginRidePage extends StatelessWidget {
       [
         _StopData(false, DateTime.now(), "Upson Hall", "124 Hoy Rd"),
         _StopData(true, DateTime.now(), "Uris Hall", "109 Tower Rd")
-      ]);
+      ],
+      "d38dab88-ace5-42b6-ae60-ca1d1dc8cde7");
+
+  bool _requestedContinue = false;
 
   Widget _picAndName(BuildContext context) {
     return Center(
@@ -155,25 +165,43 @@ class BeginRidePage extends StatelessWidget {
     return Scaffold(
         backgroundColor: Colors.white,
         appBar: ReturnHomeBar(),
-        body: Padding(
-          padding: EdgeInsets.only(left: 16, right: 16, bottom: 15, top: 24),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              _picAndName(context),
-              SizedBox(height: 48),
-              Stops(stops: data.stops),
-              Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: CButton(
-                    text: "Begin Ride",
-                    onPressed: () {
-                      // TODO: backend update functionality
-                      // TODO: push next page in flow
-                    }),
-              ),
-            ],
+        body: LoadingOverlay(
+          color: Colors.white,
+          opacity: 0.3,
+          isLoading: _requestedContinue,
+          child: Padding(
+            padding: EdgeInsets.only(left: 16, right: 16, bottom: 15, top: 24),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _picAndName(context),
+                SizedBox(height: 48),
+                Stops(stops: data.stops),
+                Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: CButton(
+                      text: "Begin Ride",
+                      onPressed: () async {
+                        if (_requestedContinue) return;
+                        setState(() => _requestedContinue = true);
+                        final response = await updateRideStatus(
+                            context, data.rideId, RideStatus.ON_THE_WAY);
+                        if (!mounted) return;
+                        if (response.statusCode == 200) {
+                          Navigator.pushReplacement(
+                              context,
+                              MaterialPageRoute(
+                                  builder: (BuildContext context) =>
+                                      OnTheWayPage()));
+                        } else {
+                          setState(() => _requestedContinue = false);
+                          throw Exception('Failed to update ride status');
+                        }
+                      }),
+                ),
+              ],
+            ),
           ),
         ));
   }

--- a/lib/pages/OnTheWayPage.dart
+++ b/lib/pages/OnTheWayPage.dart
@@ -1,9 +1,11 @@
 import 'package:carriage/Ride.dart';
+import 'package:carriage/pages/PickUpPage.dart';
 import 'package:carriage/widgets/AppBars.dart';
 import 'package:carriage/widgets/Buttons.dart';
 import 'package:carriage/widgets/Dialogs.dart';
 import 'package:carriage/widgets/RideInfoCard.dart';
 import 'package:flutter/material.dart';
+import 'package:loading_overlay/loading_overlay.dart';
 
 // TODO: replace with real model later
 class _TempPageData {
@@ -12,58 +14,86 @@ class _TempPageData {
   final DateTime time;
   final String stop;
   final String address;
+  final String rideId;
 
-  _TempPageData(this.firstName, this.photo, this.time, this.stop, this.address);
+  _TempPageData(this.firstName, this.photo, this.time, this.stop, this.address,
+      this.rideId);
 }
 
-class OnTheWayPage extends StatelessWidget {
+class OnTheWayPage extends StatefulWidget {
+  @override
+  _OnTheWayPageState createState() => _OnTheWayPageState();
+}
+
+class _OnTheWayPageState extends State<OnTheWayPage> {
   final _TempPageData data = _TempPageData(
       "Alex",
       NetworkImage(
           "https://www.acouplecooks.com/wp-content/uploads/2019/05/Chopped-Salad-001_1-225x225.jpg"),
       DateTime.now(),
       "Upson Hall",
-      "124");
+      "124",
+      "d38dab88-ace5-42b6-ae60-ca1d1dc8cde7");
+
+  bool _requestedContinue = false;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
         backgroundColor: Colors.white,
         appBar: ReturnHomeBar(),
-        body: Padding(
-          padding: EdgeInsets.only(left: 40, right: 40, bottom: 15, top: 24),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Text("On your way to...",
-                  style: Theme.of(context).textTheme.headline5),
-              SizedBox(height: 59),
-              RideInfoCard(data.firstName, data.photo, false, data.stop,
-                  data.address, data.time),
-              Expanded(child: SizedBox()),
-              CButton(
-                  text: "Arrive",
-                  onPressed: () {
-                    // TODO: arrive functionality
-                    // TODO: push next page in flow
-                  }),
-              DangerButton(
-                  text: "Notify Delay",
-                  onPressed: () {
-                    showDialog(
-                        context: context,
-                        builder: (_) => ConfirmDialog(
-                              actionName: "Notify",
-                              onConfirm: () {
-                                // TODO: notify delay functionality
-                              },
-                              content: Text(
-                                  "Do you want to notify the rider about your delay?"),
-                            ),
-                        barrierDismissible: true);
-                  })
-            ],
+        body: LoadingOverlay(
+          color: Colors.white,
+          opacity: 0.3,
+          isLoading: _requestedContinue,
+          child: Padding(
+            padding: EdgeInsets.only(left: 40, right: 40, bottom: 15, top: 24),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text("On your way to...",
+                    style: Theme.of(context).textTheme.headline5),
+                SizedBox(height: 59),
+                RideInfoCard(data.firstName, data.photo, false, data.stop,
+                    data.address, data.time),
+                Expanded(child: SizedBox()),
+                CButton(
+                    text: "Arrive",
+                    onPressed: () async {
+                      if (_requestedContinue) return;
+                      setState(() => _requestedContinue = true);
+                      final response = await updateRideStatus(
+                          context, data.rideId, RideStatus.ARRIVED);
+                      if (!mounted) return;
+                      if (response.statusCode == 200) {
+                        Navigator.pushReplacement(
+                            context,
+                            MaterialPageRoute(
+                                builder: (BuildContext context) =>
+                                    PickUpPage()));
+                      } else {
+                        setState(() => _requestedContinue = false);
+                        throw Exception('Failed to update ride status');
+                      }
+                    }),
+                DangerButton(
+                    text: "Notify Delay",
+                    onPressed: () {
+                      showDialog(
+                          context: context,
+                          builder: (_) => ConfirmDialog(
+                                actionName: "Notify",
+                                onConfirm: () {
+                                  // TODO: notify delay functionality
+                                },
+                                content: Text(
+                                    "Do you want to notify the rider about your delay?"),
+                              ),
+                          barrierDismissible: true);
+                    })
+              ],
+            ),
           ),
         ));
   }

--- a/lib/pages/PickUpPage.dart
+++ b/lib/pages/PickUpPage.dart
@@ -4,6 +4,7 @@ import 'package:carriage/widgets/Buttons.dart';
 import 'package:carriage/widgets/Dialogs.dart';
 import 'package:carriage/widgets/RideInfoCard.dart';
 import 'package:flutter/material.dart';
+import 'package:loading_overlay/loading_overlay.dart';
 
 // TODO: replace with real model later
 class _TempPageData {
@@ -12,58 +13,88 @@ class _TempPageData {
   final DateTime time;
   final String stop;
   final String address;
+  final String rideId;
 
-  _TempPageData(this.firstName, this.photo, this.time, this.stop, this.address);
+  _TempPageData(this.firstName, this.photo, this.time, this.stop, this.address,
+      this.rideId);
 }
 
-class PickUpPage extends StatelessWidget {
+class PickUpPage extends StatefulWidget {
+  @override
+  _PickUpPageState createState() => _PickUpPageState();
+}
+
+class _PickUpPageState extends State<PickUpPage> {
   final _TempPageData data = _TempPageData(
       "Alex",
       NetworkImage(
           "https://www.acouplecooks.com/wp-content/uploads/2019/05/Chopped-Salad-001_1-225x225.jpg"),
       DateTime.now(),
       "Upson Hall",
-      "124");
+      "124",
+      "d38dab88-ace5-42b6-ae60-ca1d1dc8cde7");
+
+  bool _requestedContinue = false;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
         backgroundColor: Colors.white,
         appBar: ReturnHomeBar(),
-        body: Padding(
-          padding: EdgeInsets.only(left: 40, right: 40, bottom: 15, top: 24),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Text("Is ${data.firstName} here?",
-                  style: Theme.of(context).textTheme.headline5),
-              SizedBox(height: 59),
-              RideInfoCard(data.firstName, data.photo, false, data.stop,
-                  data.address, data.time),
-              Expanded(child: SizedBox()),
-              CButton(
-                  text: "Pick up",
-                  onPressed: () {
-                    // TODO: arrive functionality
-                    // TODO: push next page in flow
-                  }),
-              DangerButton(
-                  text: "Report No Show",
-                  onPressed: () {
-                    showDialog(
-                        context: context,
-                        builder: (_) => ConfirmDialog(
-                              actionName: "Notify",
-                              onConfirm: () {
-                                // TODO: notify delay functionality
-                              },
-                              content: Text(
-                                  "Do you want to notify the dispatcher of a No Show?"),
-                            ),
-                        barrierDismissible: true);
-                  })
-            ],
+        body: LoadingOverlay(
+          color: Colors.white,
+          opacity: 0.3,
+          isLoading: _requestedContinue,
+          child: Padding(
+            padding: EdgeInsets.only(left: 40, right: 40, bottom: 15, top: 24),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text("Is ${data.firstName} here?",
+                    style: Theme.of(context).textTheme.headline5),
+                SizedBox(height: 59),
+                RideInfoCard(data.firstName, data.photo, false, data.stop,
+                    data.address, data.time),
+                Expanded(child: SizedBox()),
+                CButton(
+                    text: "Pick up",
+                    onPressed: () async {
+                      if (_requestedContinue) return;
+                      setState(() => _requestedContinue = true);
+                      final response = await updateRideStatus(
+                          context, data.rideId, RideStatus.PICKED_UP);
+                      if (!mounted) return;
+                      if (response.statusCode == 200) {
+                        // TODO: push next page in flow
+                        // TEMP: cancel loading circle
+                        setState(() => _requestedContinue = false);
+                        // Navigator.pushReplacement(
+                        //     context,
+                        //     MaterialPageRoute(
+                        //         builder: (BuildContext context) => ???()));
+                      } else {
+                        setState(() => _requestedContinue = false);
+                        throw Exception('Failed to update ride status');
+                      }
+                    }),
+                DangerButton(
+                    text: "Report No Show",
+                    onPressed: () {
+                      showDialog(
+                          context: context,
+                          builder: (_) => ConfirmDialog(
+                                actionName: "Notify",
+                                onConfirm: () {
+                                  // TODO: notify delay functionality
+                                },
+                                content: Text(
+                                    "Do you want to notify the dispatcher of a No Show?"),
+                              ),
+                          barrierDismissible: true);
+                    })
+              ],
+            ),
           ),
         ));
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -109,6 +109,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.16.1"
+  loading_overlay:
+    dependency: "direct main"
+    description:
+      name: loading_overlay
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.1"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   geolocation: ^1.1.2
   provider: ^4.0.5+1
   wakelock: ^0.1.4+2
+  loading_overlay: ^0.2.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Summary <!-- Required -->

Adds ride status update requests to each stage of the ride flow. The next page at each stage in the flow is opened only when the ride status update is confirmed successful. A loading circle appears until the update request is completed or returns an error.

### Test Plan <!-- Required -->

Tested manually with Postman. Confirmed ride statuses are updated correctly for a sample ride.


### Notes <!-- Optional -->

Currently, if the status update fails, opening the next page in the flow is cancelled. We may want to add error messages to explain to the user why the update failed.
