### PR TITLE
Add quickfix for Profile loading

### DIFF
--- a/lib/Profile.dart
+++ b/lib/Profile.dart
@@ -133,13 +133,7 @@ class _ProfileState extends State<Profile> {
             "Schedule Info",
             [
               InfoRow("hours", Icons.schedule,
-                  "${userInfoProvider.info.startTime} to ${userInfoProvider.info.endTime}"),
-              InfoRow(
-                  "breaks",
-                  Icons.free_breakfast,
-                  (userInfoProvider.info.breaks == null)
-                      ? 'None'
-                      : userInfoProvider.info.breaks.toString()),
+                  "${userInfoProvider.info.availability}"),
               InfoRow("vehicle", Icons.directions_car,
                   userInfoProvider.info.vehicle),
             ],

--- a/lib/UserInfoProvider.dart
+++ b/lib/UserInfoProvider.dart
@@ -84,14 +84,8 @@ class UserInfo {
   ///The last name of the driver.
   final String lastName;
 
-  ///Time that the driver starts working.
-  final String startTime;
-
-  ///Time that the driver stops working.
-  final String endTime;
-
-  ///The driver's breaks.
-  final Breaks breaks;
+  ///Time that the driver works.
+  final Map<String, dynamic> availability;
 
   ///Name of the vehicle the driver uses.
   final String vehicle;
@@ -109,9 +103,7 @@ class UserInfo {
   UserInfo(
       {this.firstName,
       this.lastName,
-      this.startTime,
-      this.endTime,
-      this.breaks,
+      this.availability,
       this.vehicle,
       this.phoneNumber,
       this.email,
@@ -122,9 +114,7 @@ class UserInfo {
     return UserInfo(
         firstName: json['firstName'],
         lastName: json['lastName'],
-        startTime: json['startTime'],
-        endTime: json['endTime'],
-        breaks: Breaks.fromJson(json['breaks']),
+        availability: json['availability'],
         vehicle: json['vehicle']['name'],
         phoneNumber: json['phoneNumber'],
         email: json['email'],


### PR DESCRIPTION
### Summary <!-- Required -->
Changes on the backend that replaced breaks with availability prevented the profile page from loading as it was expecting data from the outdated model. This PR is a quick fix to get the profile page to load again. It does not deal with properly formatting the availability information for display.
<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

### Test Plan <!-- Required -->
Go the profile page and see that it loads, displaying the availability object where breaks used to be.
<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->
Formatting of the availability data on the profile page will be handled by another PR. I have added a task for it to the Driver Backlog on the Monday board.
<!--- List any important or subtle points, future considerations, or other items of note. -->
