### PR TITLE
Ride grid style and drop off fixes

### DIFF
--- a/lib/pages/Rides.dart
+++ b/lib/pages/Rides.dart
@@ -232,8 +232,7 @@ class _RidesState extends State<Rides> {
 
   @override
   Widget build(BuildContext context) {
-    RidesProvider ridesProvider =
-    Provider.of<RidesProvider>(context, listen: false);
+    RidesProvider ridesProvider = Provider.of<RidesProvider>(context);
 
     List<Ride> currentRides = ridesProvider.currentRides;
     List<Ride> remainingRides = ridesProvider.remainingRides;

--- a/lib/widgets/RideInProgressCard.dart
+++ b/lib/widgets/RideInProgressCard.dart
@@ -18,30 +18,60 @@ class RideInProgressCard extends StatelessWidget {
       },
       child: DecoratedBox(
         decoration: BoxDecoration(
-            color:
-            selected ? Color.fromRGBO(167, 167, 167, 0.4) : Colors.white,
+            color: selected ? CarriageTheme.gray3.withOpacity(0.2) : Colors.white,
             borderRadius: BorderRadius.all(Radius.circular(8)),
-            boxShadow: [CarriageTheme.shadow]),
+            boxShadow: selected ? [
+              BoxShadow(
+                  blurRadius: 2,
+                  color: CarriageTheme.gray3.withOpacity(0.2)
+              )
+            ] : [CarriageTheme.shadow]
+        ),
         child: Stack(
             children: [
               Padding(
                 padding: EdgeInsets.only(left: 8, top: 8),
                 child: selected
                     ? Icon(Icons.check_circle, size: 20, color: Colors.black)
-                    : Container(
-                  width: 20,
-                  height: 20,
-                  decoration: BoxDecoration(
-                      shape: BoxShape.circle, color: Color.fromRGBO(196, 196, 196, 0.5)),
-                ),
+                    : Icon(Icons.circle, size: 20, color: Color.fromRGBO(196, 196, 196, 0.5))
               ),
               Container(
                 padding: const EdgeInsets.all(16),
                 child: Column(mainAxisSize: MainAxisSize.max, children: [
                   Center(
-                    child: CircleAvatar(
-                      radius: 16,
-                      backgroundImage: AssetImage('assets/images/terry.jpg'),
+                    child: Stack(
+                      clipBehavior: Clip.none,
+                      children: [
+                        CircleAvatar(
+                          radius: 16,
+                          backgroundImage: AssetImage('assets/images/terry.jpg'),
+                        ),
+                      Positioned(
+                        top: 16,
+                        left: 23,
+                        child: Stack(
+                          alignment: Alignment.center,
+                          children: [
+                            Container(
+                                width: 18,
+                                height: 18,
+                                decoration: BoxDecoration(
+                                    borderRadius: BorderRadius.circular(100),
+                                    color: Colors.white
+                                ),
+                            ),
+                            Container(
+                                width: 14,
+                                height: 14,
+                                decoration: BoxDecoration(
+                                    borderRadius: BorderRadius.circular(100),
+                                    color: Color.fromRGBO(111, 207, 151, 1)
+                                )
+                            )
+                          ],
+                        )
+                      ),
+                      ],
                     ),
                   ),
                   SizedBox(height: 8),


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is the first step towards fixing the current ride grid

- [x] fixed background color when selecting a card
- [x] fixed circle size
- [x] added green circle to match designs
- [x] fixed provider so that the page updates automatically after dropping off a ride

### Test Plan <!-- Required -->
Unselected:
<img src="https://user-images.githubusercontent.com/60579411/111053553-b4b62800-8432-11eb-8435-61c73f2338a3.png" width="300">

Selected:
<img src="https://user-images.githubusercontent.com/60579411/111053465-1033e600-8432-11eb-8446-c888517183af.png" width="300">

Dropped off two rides, confirmed page changed to remove both rides. Dropped off one ride, confirmed page changed to remove that ride.

<!-- Provide screenshots or point out the additional unit tests -->
