### PR TITLE
Updated ride group headings to be full hour

### DIFF
--- a/lib/pages/Rides.dart
+++ b/lib/pages/Rides.dart
@@ -297,17 +297,10 @@ class RideGroup extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    int hour12 = hour;
-    String period;
-    if (hour < 12) {
-      period = 'AM';
-    } else {
-      period = 'PM';
-      if (hour > 12) {
-        hour12 -= 12;
-      }
-    }
-    String title = '$hour12:00 ~ $hour12:50 ' + period;
+    DateTime startHour = DateTime(0, 0, 0, hour, 0);
+    DateTime endHour = startHour.add(Duration(hours: 1));
+
+    String title = DateFormat('jm').format(startHour) + ' ~ ' + DateFormat('jm').format(endHour);
 
     return Padding(
       padding: EdgeInsets.symmetric(horizontal: 16),


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is the first step towards updating the ride group headings

- [x] changed time headings to be <hour> AM/PM ~ <next hour> AM/PM 

### Test Plan <!-- Required -->
AM to AM:
<img src="https://scontent-iad3-2.xx.fbcdn.net/v/t1.15752-9/s1080x2048/172603700_298183988382274_7243153211406557097_n.png?_nc_cat=105&_nc_map=test-rt&ccb=1-3&_nc_sid=ae9488&_nc_ohc=IbZSRwcm1VwAX_AyPof&_nc_ht=scontent-iad3-2.xx&_nc_tp=30&oh=a4397e0660f6452789016cf66dfa5e7e&oe=609AD134" width="300" />

11 AM to 12 PM: 
<img src="https://scontent-iad3-2.xx.fbcdn.net/v/t1.15752-9/s1080x2048/172434364_266651871804649_8198304320465601826_n.png?_nc_cat=104&_nc_map=test-rt&ccb=1-3&_nc_sid=ae9488&_nc_ohc=hDMzP0JUrPwAX-CIq15&_nc_ht=scontent-iad3-2.xx&_nc_tp=30&oh=4155e8531cc62b22b63c9ae5790fac6a&oe=6098C986" width="300" />

PM to PM:
<img src="https://scontent-iad3-2.xx.fbcdn.net/v/t1.15752-9/s1080x2048/172484484_504408357262731_6917234075502701906_n.png?_nc_cat=101&_nc_map=test-rt&ccb=1-3&_nc_sid=ae9488&_nc_ohc=pvyEczP99SMAX_5fHFL&_nc_ht=scontent-iad3-2.xx&_nc_tp=30&oh=36e5efe2ab7f4a1edc7d4054b5fccdcc&oe=60996F02" width="300" />
