### PR TITLE
Removed legal row from profile, fixed removing no show rides

### DIFF
--- a/lib/pages/Profile.dart
+++ b/lib/pages/Profile.dart
@@ -157,9 +157,6 @@ class Profile extends StatelessWidget {
               sectionDivider,
               // commenting out right now because this is likely being removed or pushed to v2
               //SettingRow('Notifications', 'Set your notification preferences', NotificationSettings()),
-              //TODO: implement this
-              SettingRow('Legal', 'Terms of Service & Privacy Policy', Container()),
-              sectionDivider,
               SignOutButton()
             ],
           ),

--- a/lib/pages/ride-flow/PickUpPage.dart
+++ b/lib/pages/ride-flow/PickUpPage.dart
@@ -1,3 +1,6 @@
+import 'package:carriage/providers/RidesProvider.dart';
+import 'package:provider/provider.dart';
+
 import '../../utils/MeasureRect.dart';
 import 'package:carriage/widgets/Buttons.dart';
 import 'package:carriage/widgets/Dialogs.dart';
@@ -180,6 +183,8 @@ class _PickUpPageState extends State<PickUpPage> {
                                                   final pastResponse = await setRideToPast(
                                                       context, widget.ride.id);
                                                   if (pastResponse.statusCode == 200) {
+                                                    RidesProvider ridesProvider = Provider.of<RidesProvider>(context, listen: false);
+                                                    ridesProvider.finishCurrentRide(widget.ride);
                                                     Navigator.of(context).pushReplacement(
                                                         MaterialPageRoute(
                                                             builder:
@@ -197,6 +202,7 @@ class _PickUpPageState extends State<PickUpPage> {
                                             ),
                                             barrierDismissible: true
                                         );
+
                                       }
                                   ),
                                 ]


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request includes minor fixes:

- [x] Remove legal row from profile page
- [x] Remove rides from homepage after marked as no show 

### Test Plan <!-- Required -->
Profile:
![image](https://user-images.githubusercontent.com/60579411/119278618-5d7fc100-bbf4-11eb-8aee-bc98817da49e.png)

No show rides:
Created ride on admin web, marked ride as no show, navigated back to homepage to confirm that ride did not show up again, confirmed on admin web that ride is marked as no show.
Repeated process for a ride where I also paused ride.
Repeated process for a ride where I also notified rider of delay.
Repeated process for a ride where I paused ride and notified rider of delay.